### PR TITLE
更新了mcp工具，并顺带将父项目SpringBoot依赖升级到了3.4.12

### DIFF
--- a/src/main/java/top/codestyle/mcp/config/CodestyleMCPToolsConfig.java
+++ b/src/main/java/top/codestyle/mcp/config/CodestyleMCPToolsConfig.java
@@ -1,0 +1,24 @@
+package top.codestyle.mcp.config;
+
+import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.ai.tool.method.MethodToolCallbackProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import top.codestyle.mcp.service.CodestyleService;
+
+/**
+ * 管理MCP工具的注册 配置类
+ *
+ * @author ChonghaoGao
+ * @date 2025/12/13 22:44)
+ */
+@Configuration
+public class CodestyleMCPToolsConfig {
+
+    @Bean
+    public ToolCallbackProvider codestyleTools(CodestyleService codestyleService){
+        return MethodToolCallbackProvider.builder().toolObjects(codestyleService).build();
+    }
+
+    //可以拓展新的工具
+}

--- a/src/main/java/top/codestyle/mcp/config/RepositoryConfig.java
+++ b/src/main/java/top/codestyle/mcp/config/RepositoryConfig.java
@@ -15,7 +15,7 @@ import java.nio.file.Paths;
  * 仓库配置类
  * 管理仓库路径和缓存目录配置
  *
- * @author 小航love666, Kanttha, movclantian
+ * @author 小航love666, Kanttha, movclantian chonghaoGao
  * @since 2025-09-29
  */
 @Configuration

--- a/src/main/java/top/codestyle/mcp/model/sdk/RemoteMetaConfig.java
+++ b/src/main/java/top/codestyle/mcp/model/sdk/RemoteMetaConfig.java
@@ -66,7 +66,7 @@ public class RemoteMetaConfig {
         /**
          * 输入变量列表
          */
-        private List<MetaVariable> inputVarivales;
+        private List<MetaVariable> metaVariables;
         
         /**
          * 文件SHA256哈希值

--- a/src/main/java/top/codestyle/mcp/service/CodestyleService.java
+++ b/src/main/java/top/codestyle/mcp/service/CodestyleService.java
@@ -1,8 +1,8 @@
 package top.codestyle.mcp.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springaicommunity.mcp.annotation.McpTool;
-import org.springaicommunity.mcp.annotation.McpToolParam;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.stereotype.Service;
 import top.codestyle.mcp.model.meta.LocalMetaInfo;
 import top.codestyle.mcp.model.sdk.MetaInfo;
@@ -37,11 +37,11 @@ public class CodestyleService {
      * @param templateKeyword 模板提示词,如: CRUD, backend, frontend等
      * @return 模板目录树和描述信息
      */
-    @McpTool(name = "codestyleSearch", description = """
+    @Tool(name = "codestyleSearch", description = """
             根据模板提示词搜索代码模板库，返回匹配的模板目录树和模板组介绍。
             """)
     public String codestyleSearch(
-            @McpToolParam(description = "模板提示词，如: CRUD, bankend, frontend等") String templateKeyword) {
+            @ToolParam(description = "模板提示词，如: CRUD, bankend, frontend等") String templateKeyword) {
         try {
             String groupId;
             String artifactId;
@@ -120,9 +120,9 @@ public class CodestyleService {
      * @return 模板文件的详细信息(变量+内容)
      * @throws IOException 文件读取异常
      */
-    @McpTool(name = "getTemplateByPath", description = "传入模板文件路径,获取模板文件的详细内容(包括变量说明和模板代码)")
+    @Tool(name = "getTemplateByPath", description = "传入模板文件路径,获取模板文件的详细内容(包括变量说明和模板代码)")
     public String getTemplateByPath(
-            @McpToolParam(description = "模板文件路径,如:backend/CRUD/1.0.0/src/main/java/com/air/controller/Controller.ftl") String templatePath)
+            @ToolParam(description = "模板文件路径,如:backend/CRUD/1.0.0/src/main/java/com/air/controller/Controller.ftl") String templatePath)
             throws IOException {
 
         // 使用精确路径搜索模板

--- a/src/main/java/top/codestyle/mcp/util/MetaInfoConvertUtil.java
+++ b/src/main/java/top/codestyle/mcp/util/MetaInfoConvertUtil.java
@@ -164,7 +164,7 @@ public class MetaInfoConvertUtil {
                 localFile.setFilename(remoteFile.getFilename());
                 localFile.setDescription(remoteFile.getDescription());
                 localFile.setSha256(remoteFile.getSha256());
-                localFile.setInputVariables(remoteFile.getInputVarivales());
+                localFile.setInputVariables(remoteFile.getMetaVariables());
                 localFiles.add(localFile);
             }
         }

--- a/src/main/java/top/codestyle/mcp/util/SDKUtils.java
+++ b/src/main/java/top/codestyle/mcp/util/SDKUtils.java
@@ -102,13 +102,13 @@ public class SDKUtils {
      * 从远程仓库获取元配置
      *
      * @param remoteBaseUrl   远程仓库基础URL
-     * @param templateKeyword 模板关键词,如: RuoYi, CRUD
+     * @param query 模板关键词,如: RuoYi, CRUD
      * @return 远程模板配置,失败返回null
      */
-    public static RemoteMetaConfig fetchRemoteMetaConfig(String remoteBaseUrl, String templateKeyword) {
+    public static RemoteMetaConfig fetchRemoteMetaConfig(String remoteBaseUrl, String query) {
         try {
             String responseBody = HttpRequest.get(remoteBaseUrl + "/api/mcp/search")
-                    .form("templateKeyword", templateKeyword)
+                    .form("query", query)
                     .timeout(30000)
                     .header("User-Agent", "MCP-CodeStyle-Server/1.0")
                     .execute()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,15 +13,13 @@ spring:
         version: 1.0.0 # 服务器版本
         type: SYNC # 服务器类型: SYNC(同步) 或 ASYNC(异步)
         stdio: true # 启用stdio模式
-        annotation-scanner:
-          enabled: true # 启用注解扫描
 # 仓库配置
 repository:
   # 本地基础路径，可通过JVM参数 -Dcache.base-path=自定义路径 覆盖
   # 示例: java -Dcache.base-path=/custom/path -jar app.jar
-  local-path: /var/cache/codestyle # 默认本地路径
-  remote-path: http://localhost # 远程仓库地址
+  local-path: D:/cache/codestyle # 默认本地路径
+  remote-path: http://localhost:8080 # 远程仓库地址
   # 仓库目录配置(可选,不配置则自动使用 local-path/codestyle-cache)
   dir: /var/cache/codestyle/codestyle-cache
   # 是否启用远程检索(默认false,使用本地Lucene检索)
-  remote-search-enabled: false
+  remote-search-enabled: true

--- a/src/test/java/top/codestyle/mcp/service/CodestyleServiceTest.java
+++ b/src/test/java/top/codestyle/mcp/service/CodestyleServiceTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.transport.ServerParameters;
 import io.modelcontextprotocol.client.transport.StdioClientTransport;
-import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 
 import org.springframework.boot.test.context.SpringBootTest;
@@ -36,8 +35,8 @@ class CodestyleServiceTest {
                         Root_Path + "/target/mcp-codestyle-server-0.0.1.jar")
                 .build();
 
-        var jsonMapper = new JacksonMcpJsonMapper(new ObjectMapper());
-        var transport = new StdioClientTransport(stdioParams, jsonMapper);
+//        var jsonMapper = new JacksonMcpJsonMapper(); 升级版不需要构建专用的JsonMapper
+        var transport = new StdioClientTransport(stdioParams, new ObjectMapper());
         var client = McpClient.sync(transport).build();
 
         client.initialize();


### PR DESCRIPTION
原本的@McpTool注解被替换为了@Tool注解，隶属于SpringAI社区的注解被换成了org.springframework官方的MCP注解，并升级了整个项目SpringBoot版本，没有破坏内置SDK部分！