### PR TITLE
# 优化对项目的理解能力和处理流程，优化token消耗

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   
   # Codestyle Server MCP【码蜂】
   
-  基于 Spring AI 的 MCP 服务器，为 IDE 和 AI 代理提供代码模板搜索和检索工具。
+  基于 Spring AI 的 MCP 服务器，为 IDE 和 AI 代理提供代码分析与代码模板搜索、检索工具。
   
   [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
   [![Java](https://img.shields.io/badge/Java-17+-orange.svg)](https://www.oracle.com/java/)
@@ -14,7 +14,11 @@
 
 ## 🚀 核心特性
 
-- **MCP 工具**：`codestyleSearch` / `getTemplateByPath` / `uploadTemplate` / `uploadTemplateFromFileSystem` / `deleteTemplate` / `extractProjectSkeleton` / `exploreCodeContext`，支持 Cherry Studio、Cursor、TRAE 等 MCP 客户端
+- **MCP 工具**：支持 Cherry Studio、Cursor、TRAE 等 MCP 客户端
+  - **代码分析**：`analyzeProject`（一站式分析，3～6 个关键词→位置+调用链+预览）、`exploreCodeContext`（expand / trace / search 读代码）
+  - **模板**：`codestyleSearch` / `getTemplateByPath` / `uploadTemplate` / `uploadTemplateFromFileSystem` / `deleteTemplate`
+  - **骨架**：`extractProjectSkeleton`（AST 解析项目骨架）
+- **工具组**：通过 `codestyle.tool-group` 按需暴露工具，**默认 `all`** 暴露全部工具；若仅需代码分析可设为 `analyze`（2 工具），减少客户端 token
 - **Lucene 全文检索**：中文分词（SmartChineseAnalyzer），离线可用
 - **双模式检索**：本地 Lucene（默认） / 远程 Open API（签名认证）
 - **配置验证**：启动时自动验证配置，快速失败
@@ -60,6 +64,8 @@ mvn clean package -DskipTests
   }
 }
 ```
+
+默认 `all` 暴露全部工具；若仅需代码分析（2 工具）可加 `-Dcodestyle.tool-group=analyze`。
 
 **配置示例**：
 
@@ -187,6 +193,20 @@ repository:
 |--------|------|--------|----------|
 | `CODESTYLE_CACHE_PATH` | 本地缓存路径 | `./mcp-cache` | 不同环境使用不同的缓存目录 |
 | `CODESTYLE_REMOTE_ENABLED` | 是否启用远程检索 | `false` | 开发环境关闭，生产环境开启 |
+| `CODESTYLE_TOOL_GROUP` | 暴露的 MCP 工具组 | `all` | 见上表；仅需代码分析时可设为 `analyze` |
+
+**工具组**（`codestyle.tool-group`，可选）：
+
+| 取值 | 暴露工具 | 说明 |
+|------|----------|------|
+| `all`（默认） | 全部 | 所有工具均注册 |
+| `analyze` | `analyzeProject` + `exploreCodeContext` | 仅 2 个代码分析工具，无需先调 extractProjectSkeleton |
+| `fast-analysis` | `analyzeProject` | 仅一站式分析 |
+| `explore` | `exploreCodeContext` | 仅代码展开/追踪/搜索 |
+| `code-analysis` | `extractProjectSkeleton` | 传统骨架解析（需先解析再 explore） |
+| `template` | 模板 7 工具 | codestyleSearch / getTemplateByPath / upload / delete 等 |
+
+可通过 JVM 参数或环境变量覆盖：`-Dcodestyle.tool-group=all` 或 `CODESTYLE_TOOL_GROUP=all`。
 
 **骨架与图相关配置**（`codestyle.*`，可选）：
 
@@ -244,7 +264,44 @@ java -jar codestyle-server.jar --spring.profiles.active=prod
 
 ## 🛠️ MCP 工具
 
-### codestyleSearch
+### 代码分析（analyze 组或 all）
+
+#### analyzeProject
+
+一站式代码分析：传入项目路径与 3～6 个核心函数/类名（逗号分隔），一次返回 Summary、Call Flow、每个关键词的位置（`file:startLine-endLine`）、签名与代码预览；内部自动构建并缓存骨架，**无需先调用 extractProjectSkeleton**。适合 Cursor 等 AI 先全局理解再按需读代码。
+
+```
+输入:
+  - projectPath: 项目目录绝对路径
+  - keywords: 3～6 个核心函数/类名，逗号分隔（如: aquery_llm, kg_query, insert）
+  - focusPath: 可选，聚焦子目录（如 src/main）
+
+输出: Markdown 报告（项目概览、Call Flow、每关键词位置+预览）；增量调用时若关键词已缓存则返回精简摘要，建议用 exploreCodeContext(expand) 读代码
+```
+
+#### exploreCodeContext
+
+基于 analyzeProject 已缓存的骨架与依赖图，按意图精准读取代码。支持 **expand**（按文件/行范围批量读代码，支持 `file1:start-end|file2:start-end`，单次批量 12K 字符按目标数均分）、**trace**（上下游调用链）、**search**（按名称搜索）。
+
+```
+输入:
+  - projectPath: 项目目录绝对路径（analyzeProject 会自动缓存骨架）
+  - mode: expand / trace / search
+  - query: 文件路径、类名、方法名或关键词；expand 支持 | 分隔批量
+  - direction: trace 时 upstream / downstream / both（默认 both）
+  - maxDepth: 最大遍历深度（默认 3）
+  - lineRange: expand 时可选行范围，如 100-200（1 基，含端点）
+
+输出: 展开的代码片段 / 调用链 / 搜索结果
+```
+
+**推荐工作流**：先 `analyzeProject(projectPath, keywords)` → 从报告取 `file:start-end` → `exploreCodeContext(mode=expand, query="file:start-end|...")` 批量读代码；理解调用关系时用 `mode=trace, query="函数名"`。
+
+---
+
+### 模板工具（组 `template` 或 `all`）
+
+#### codestyleSearch
 
 搜索模板，返回目录树 + 描述。
 
@@ -316,9 +373,9 @@ java -jar codestyle-server.jar --spring.profiles.active=prod
   - 索引已更新
 ```
 
-### extractProjectSkeleton
+### extractProjectSkeleton（组 `code-analysis` 或 `all`）
 
-对指定项目目录执行多语言 AST 深度解析，构建层级代码树 (HCT) 与多类型依赖图 (MDG)，通过 PageRank + 复合评分智能剪枝，以 **Markdown+XML** 混合格式返回精简骨架。支持 Java、Python、JavaScript、TypeScript、Go。
+对指定项目目录执行多语言 AST 深度解析，构建层级代码树 (HCT) 与多类型依赖图 (MDG)，以 **Markdown+XML** 混合格式返回精简骨架。支持 Java、Python、JavaScript、TypeScript、Go。在默认组 `all` 下会暴露；若仅需代码分析可设 `codestyle.tool-group=analyze`，则不含本工具。
 
 ```
 输入:
@@ -327,21 +384,6 @@ java -jar codestyle-server.jar --spring.profiles.active=prod
   - focusPath: 可选，聚焦子目录（如 src/main），仅解析该目录
 
 输出: Markdown + <directory_tree> / <ast_skeleton> / <dependency_graph> 混合文档
-```
-
-### exploreCodeContext
-
-基于已解析的骨架与依赖图，按意图检索精准代码上下文。**需先对同一 projectPath 调用 extractProjectSkeleton**。
-
-```
-输入:
-  - projectPath: 项目目录绝对路径
-  - mode: expand（展开实现）/ trace（上下游调用链）/ search（按名称搜索）
-  - query: 文件路径、类名、方法名或关键词
-  - direction: trace 时 upstream / downstream / both
-  - maxDepth: 最大遍历深度（默认 3）
-
-输出: <expanded_context> / <trace_result> / <search_result> 等
 ```
 
 ### deleteTemplate
@@ -433,7 +475,25 @@ A: 系统会自动降级到本地 Lucene 检索
 | 重建索引 | 删除 `lucene-index/` 目录，重启服务 |
 | 强制更新模板 | 删除对应的 `{groupId}/{artifactId}` 目录 |
 
+### CI / 校验
+
+- **工具组**：PR 或集成测试时默认 `all` 全量验证；若仅测代码分析可加 `-Dcodestyle.tool-group=analyze`
+- **Skill**：`skill/codestyle/` 下提供 SKILL.md 与 references，可用于代码审查与 Skill 可用性校验（参见 [Issue #26](https://github.com/itxaiohanglover/mcp-codestyle-server/issues/26)）
+
 ## 📝 更新日志
+
+### v2.2.0 (2026-03)
+
+**代码分析增强**：
+- ✅ **analyzeProject**：新增一站式代码分析工具，传入 3～6 个关键词即可获得位置、调用链与预览，无需先调 extractProjectSkeleton
+- ✅ **工具组**：默认 `codestyle.tool-group=all` 暴露全部工具；可选 `analyze` 仅暴露 analyzeProject + exploreCodeContext，减少 tools/list 体积与 token
+- ✅ **增量分析**：关键词已全部命中缓存时返回单行摘要，提示用 exploreCodeContext 读代码
+- ✅ **批量 expand**：exploreCodeContext(expand) 单次 12K 字符预算按目标数均分，避免后段目标被截断
+- ✅ **描述精简**：analyzeProject / exploreCodeContext 的 tool description 压缩，降低客户端 token
+
+**配置与文档**：
+- 支持 `CODESTYLE_TOOL_GROUP` 环境变量与 `codestyle.tool-group` 配置
+- README 补充工具组说明与推荐工作流；Skill 文档见 [skill/codestyle](skill/codestyle/)
 
 ### v2.0.0 (2026-02-24)
 

--- a/rules/mcp-codestyle-usage.mdc
+++ b/rules/mcp-codestyle-usage.mdc
@@ -1,0 +1,36 @@
+---
+description: 分析或修改代码时优先用 MCP codestyle 的 analyzeProject/exploreCodeContext（server project-0-Pipeline-codestyle），不要先用 Read/Grep 探索或读 schema
+globs: ["**"]
+alwaysApply: true
+---
+
+# MCP codestyle 工具使用规则
+
+**优先动作**：涉及理解/分析/修改任意代码时，先调用 MCP 的 `analyzeProject` 或 `exploreCodeContext`，不要先用 Cursor 的 Read/Grep 扫目录或读 mcps schema。
+
+适用：项目已接入 `mcp-codestyle-server`（server id: `project-0-Pipeline-codestyle`）。
+
+## 可用工具（直接 call_mcp_tool，无需搜索 schema）
+
+### analyzeProject（首选）
+- **server**: `project-0-Pipeline-codestyle`
+- **参数**: `projectPath`（绝对路径）, `keywords`（**3-6 个**核心函数名，逗号分隔）, `focusPath`（可选，如 `src/main`）
+- **输出**: Summary + Call Flow + 位置（行范围）/签名/代码预览；自动缓存骨架供 exploreCodeContext 使用
+
+### exploreCodeContext
+- **server**: `project-0-Pipeline-codestyle`
+- **参数**: `projectPath`, `mode`（`expand`|`search`|`trace`）, `query`
+  - expand: `file.py:100-200` 或批量 `file1:100-200|file2:300-360`
+  - search: 实体名（函数/类/文件关键词）
+  - trace: 函数/类名（可加 `direction=upstream` 或 `downstream`）
+- **lineRange**（可选，仅 expand）: `100-200`（1 基，含端点）
+
+## 标准工作流
+1. **探索**：先 `analyzeProject(projectPath, keywords=3-6 个)` → 从报告取行范围 → `exploreCodeContext(mode=expand, query="file:start-end")` 批量读代码。
+2. **调用关系**：`exploreCodeContext(mode=trace, query="函数名")` 追踪上下游。
+3. **编辑**：用 MCP 拿到改动点完整代码后再 Edit；改完用 ReadLints 验证。不要先 Read/Grep 扫目录。
+
+## 关键约束
+- **keywords 严格 3-6 个**；过多导致报告截断。
+- **不要**搜索 `mcps/` 或读 MCP tool schema 来“发现工具”。
+- **不要**单独调用 `extractProjectSkeleton`（analyzeProject 已包含）。

--- a/src/main/java/top/codestyle/mcp/config/CodestyleToolGroupCondition.java
+++ b/src/main/java/top/codestyle/mcp/config/CodestyleToolGroupCondition.java
@@ -8,10 +8,15 @@ import org.springframework.core.env.Environment;
 import java.util.Map;
 
 /**
- * P4: 根据 codestyle.tool-group 决定是否注册某组 MCP 工具。
- * code-analysis → 仅注册 CodeAnalysisService（2 工具）
- * template → 仅注册 TemplateToolService（7 工具）
- * all → 两者都注册
+ * 根据 codestyle.tool-group 决定是否注册某组 MCP 工具。
+ *
+ * 工具组说明：
+ *   all（默认）→ 全部工具；analyze → fast-analysis（analyzeProject）+ explore（exploreCodeContext），共 2 个工具
+ *   fast-analysis   → 仅 ProjectAnalysisService（1 工具 analyzeProject）
+ *   explore         → 仅 ExploreCodeService（1 工具 exploreCodeContext）
+ *   code-analysis   → 仅 CodeAnalysisService（1 工具 extractProjectSkeleton）
+ *   template        → 仅 TemplateToolService（7 工具）
+ *   all             → 全部注册
  */
 public class CodestyleToolGroupCondition implements Condition {
 
@@ -31,6 +36,11 @@ public class CodestyleToolGroupCondition implements Condition {
         if (value == null || value.isBlank()) return false;
 
         if ("all".equalsIgnoreCase(group)) return true;
+        if ("analyze".equalsIgnoreCase(group)) {
+            // 默认组：analyzeProject + exploreCodeContext，不含 extractProjectSkeleton
+            return "fast-analysis".equalsIgnoreCase(value)
+                    || "explore".equalsIgnoreCase(value);
+        }
         return value.equalsIgnoreCase(group);
     }
 }

--- a/src/main/java/top/codestyle/mcp/service/AstParsingService.java
+++ b/src/main/java/top/codestyle/mcp/service/AstParsingService.java
@@ -281,6 +281,13 @@ public class AstParsingService {
                 others.addAll(0, importList);
             }
 
+            // C3: 大文件解析诊断日志，便于排查节点未被收录原因
+            if (content.length() > 50_000) {
+                int[] counts = countClassesAndMethods(others);
+                log.info("[AST] large file {} ({} bytes): {} classes, {} methods parsed",
+                        relativePath, content.length(), counts[0], counts[1]);
+            }
+
             return AstNode.builder()
                     .nodeType("file")
                     .name(relativePath)
@@ -293,6 +300,21 @@ public class AstParsingService {
             log.debug("Tree-sitter 解析异常 [{}]: {}", relativePath, e.getMessage());
             return null;
         }
+    }
+
+    /** C3: 递归统计类数与方法数，返回 int[2] = { classes, methods }。 */
+    private static int[] countClassesAndMethods(List<AstNode> nodes) {
+        int classes = 0, methods = 0;
+        if (nodes == null) return new int[] { 0, 0 };
+        for (AstNode n : nodes) {
+            if (n == null) continue;
+            if ("class".equals(n.getNodeType()) || "interface".equals(n.getNodeType()) || "enum".equals(n.getNodeType())) classes++;
+            if ("method".equals(n.getNodeType())) methods++;
+            int[] sub = countClassesAndMethods(n.getChildren());
+            classes += sub[0];
+            methods += sub[1];
+        }
+        return new int[] { classes, methods };
     }
 
     private void visitNodeRecursive(TSNode node, String[] lines, String filePath, String ext,

--- a/src/main/java/top/codestyle/mcp/service/CodeAnalysisService.java
+++ b/src/main/java/top/codestyle/mcp/service/CodeAnalysisService.java
@@ -7,7 +7,8 @@ import org.springframework.stereotype.Service;
 import top.codestyle.mcp.config.ConditionalOnCodestyleToolGroup;
 
 /**
- * P4: 仅当 codestyle.tool-group=code-analysis 或 all 时注册，暴露 2 个代码分析 MCP 工具，减少 tools/list 体积。
+ * 仅当 codestyle.tool-group=code-analysis 或 all 时注册，暴露 extractProjectSkeleton 工具。
+ * 普通使用场景也可用 analyze 组：analyzeProject + exploreCodeContext（已自动构建骨架）；默认 all 时全部工具均注册。
  */
 @Service
 @RequiredArgsConstructor
@@ -16,23 +17,13 @@ public class CodeAnalysisService {
 
     private final CodestyleService codestyleService;
 
-    @McpTool(name = "extractProjectSkeleton", description = "[必填projectPath] AST解析项目骨架. 首次调用返回骨架,后续自动缓存. 再调exploreCodeContext探索代码.")
+    @McpTool(name = "extractProjectSkeleton", description = "[必填projectPath] AST解析项目骨架. 首次调用返回骨架,后续自动缓存. 再调exploreCodeContext探索代码.",
+            annotations = @McpTool.McpAnnotations(title = "Extract Project Skeleton", readOnlyHint = true, destructiveHint = false, idempotentHint = true, openWorldHint = false))
     public String extractProjectSkeleton(
             @McpToolParam(description = "项目目录绝对路径") String projectPath,
             @McpToolParam(required = false, description = "详情级别 1-4: 1=目录概览, 2=类骨架(推荐), 3=方法签名, 4=完整") Integer detailLevel,
             @McpToolParam(required = false, description = "可选: 聚焦的子目录路径(如 src/main)，仅解析该目录") String focusPath,
             @McpToolParam(required = false, description = "强制刷新缓存(默认false)") Boolean forceRefresh) {
         return codestyleService.extractProjectSkeleton(projectPath, detailLevel, focusPath, forceRefresh);
-    }
-
-    @McpTool(name = "exploreCodeContext", description = "[必填projectPath,mode,query] mode=search(单关键词)/expand(类名或文件路径,可加lineRange)/trace(依赖追踪). 需先调extractProjectSkeleton.")
-    public String exploreCodeContext(
-            @McpToolParam(description = "项目目录绝对路径（需先调用 extractProjectSkeleton）") String projectPath,
-            @McpToolParam(description = "模式: expand / trace / search") String mode,
-            @McpToolParam(description = "查询目标: 文件路径、类名、方法名或搜索关键词。expand 支持 | 分隔批量，如 'file1.py:100-200|file2.py:300-400'") String query,
-            @McpToolParam(required = false, description = "trace 模式方向: upstream / downstream / both (默认 both)") String direction,
-            @McpToolParam(required = false, description = "最大遍历深度 (默认 3)") Integer maxDepth,
-            @McpToolParam(required = false, description = "expand 模式可选: 行范围如 '100-200'（1基，含端点）") String lineRange) {
-        return codestyleService.exploreCodeContext(projectPath, mode, query, direction, maxDepth, lineRange);
     }
 }

--- a/src/main/java/top/codestyle/mcp/service/CodestyleService.java
+++ b/src/main/java/top/codestyle/mcp/service/CodestyleService.java
@@ -394,26 +394,7 @@ public class CodestyleService {
             if (!refresh) {
                 SkeletonCacheService.CachedSkeleton existing = skeletonCacheService.get(projectPath);
                 if (existing != null && existing.skeleton() != null) {
-                    ProjectSkeleton sk = existing.skeleton();
-                    int files = sk.getTotalFiles();
-                    int classes = sk.getTotalClasses();
-                    int methods = sk.getTotalMethods();
-                    long ageSec = (System.currentTimeMillis() - existing.buildTime()) / 1000;
-                    List<String> topClasses = extractTopClassNames(sk, 10);
-                    List<String> topMethods = extractTopMethodNames(sk, 5);
-                    List<String> fileNames = extractFileNames(sk, 8);
-                    return String.format(
-                            "[cached] 骨架已缓存 (%d文件/%d类/%d方法, %.0f秒前构建)%n" +
-                            "核心类: %s%n" +
-                            "核心方法: %s%n" +
-                            "文件: %s%n" +
-                            "--- 查询示例 ---%n" +
-                            "search(\"类名\") | expand(\"文件路径\") | expand(\"类名\") | trace(\"类名\")%n" +
-                            "expand 支持 lineRange 参数精确定位，如 lineRange=\"100-200\"。如需重新解析请传 forceRefresh=true",
-                            files, classes, methods, (double) ageSec,
-                            topClasses.isEmpty() ? "(无)" : String.join(", ", topClasses),
-                            topMethods.isEmpty() ? "(无)" : String.join(", ", topMethods),
-                            fileNames.isEmpty() ? "(无)" : String.join(", ", fileNames));
+                    return buildCacheHitSummary(existing, existing.skeleton(), projectPath);
                 }
             }
             int level = (detailLevel != null && detailLevel >= 1 && detailLevel <= 4) ? detailLevel : 2;
@@ -467,7 +448,10 @@ public class CodestyleService {
             }
             SkeletonCacheService.CachedSkeleton cached = skeletonCacheService.get(projectPath);
             if (cached == null) {
-                return "✗ 未找到该项目的骨架缓存，请先对路径 \"" + projectPath + "\" 调用 extractProjectSkeleton。";
+                cached = ensureSkeletonCached(projectPath, null);
+                if (cached == null) {
+                    return "✗ 项目骨架自动构建失败，请检查 projectPath";
+                }
             }
             String m = (mode != null && !mode.isBlank()) ? mode.strip().toLowerCase() : "search";
             int depth = (maxDepth != null && maxDepth > 0) ? Math.min(maxDepth, 20) : 3;
@@ -483,10 +467,44 @@ public class CodestyleService {
             if (result != null && !result.startsWith("✗") && callNum <= 2) {
                 result = appendNextStepHint(result, m, query);
             }
-            return outputGuardService.guard(result, projectPath, "explore-" + m, MCP_MAX_INLINE_CHARS);
+            if (result != null && !result.startsWith("✗")) {
+                int hitCount = estimateHitCount(result, m);
+                skeletonCacheService.recordExplore(projectPath, m, query, hitCount);
+            }
+            int maxChars = switch (m) {
+                case "search" -> 4_000;
+                case "expand" -> 12_000;
+                case "trace" -> 6_000;
+                default -> MCP_MAX_INLINE_CHARS;
+            };
+            return outputGuardService.guard(result, projectPath, "explore-" + m, maxChars);
         } catch (Exception e) {
             return "✗ exploreCodeContext 失败: " + e.getMessage();
         }
+    }
+
+    private static int estimateHitCount(String result, String mode) {
+        if (result == null || result.isBlank()) return 0;
+        if ("search".equals(mode)) {
+            int idx = result.indexOf(" hits)");
+            if (idx > 0) {
+                int start = result.lastIndexOf(" ", idx - 1);
+                if (start >= 0 && start < idx - 1) {
+                    try {
+                        return Integer.parseInt(result.substring(start + 1, idx).trim());
+                    } catch (NumberFormatException ignored) { }
+                }
+            }
+        }
+        if ("trace".equals(mode)) {
+            int lineCount = 0;
+            for (int i = 0; i < result.length(); i++) {
+                if (result.charAt(i) == '\n') lineCount++;
+            }
+            return Math.max(0, lineCount - 2);
+        }
+        if ("expand".equals(mode)) return 1;
+        return 0;
     }
 
     private static String appendNextStepHint(String result, String mode, String query) {
@@ -570,7 +588,7 @@ public class CodestyleService {
     private String runBatchExpand(SkeletonCacheService.CachedSkeleton cached, String projectPath, String multiQuery) {
         String[] targets = multiQuery.split("\\|");
         if (targets.length == 0) return "✗ 批量 expand 需要至少一个目标，用 | 分隔。";
-        int perTargetBudget = Math.max(500, MCP_MAX_INLINE_CHARS / targets.length);
+        int perTargetBudget = Math.max(500, EXPAND_BATCH_MAX_CHARS / targets.length);
         StringBuilder sb = new StringBuilder();
         sb.append("## batch expand (").append(targets.length).append(" targets)\n\n");
         for (String t : targets) {
@@ -885,6 +903,716 @@ public class CodestyleService {
         return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
     }
 
+    /** P3+P4: 确保骨架已缓存，不返回格式化字符串。供 runAnalyze 静默使用。 */
+    public SkeletonCacheService.CachedSkeleton ensureSkeletonCached(String projectPath, String focusPath) {
+        if (projectPath == null || projectPath.isBlank()) return null;
+        SkeletonCacheService.CachedSkeleton existing = skeletonCacheService.get(projectPath);
+        if (existing != null && existing.skeleton() != null) return existing;
+        try {
+            ProjectSkeleton skeleton = astParsingService.parseProject(projectPath, focusPath);
+            DependencyGraph graph = dependencyGraphBuilder.build(skeleton);
+            NameIndex nameIndex = NameIndex.from(graph.getNodeIndex());
+            skeletonCacheService.put(projectPath, skeleton, graph, nameIndex);
+            return skeletonCacheService.get(projectPath);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** P3: 单次搜索收集 nodeIds 与 grepHits，供 runAnalyze 使用。 */
+    private record SearchCollectResult(List<String> nodeIds, List<GrepHit> grepHits) {}
+
+    private SearchCollectResult runSingleSearchCollecting(SkeletonCacheService.CachedSkeleton cached, String projectPath, String qRaw) {
+        Map<String, AstNode> index = cached.graph() != null ? cached.graph().getNodeIndex() : Map.of();
+        String qLower = qRaw.toLowerCase();
+        NameIndex nameIndex = cached.nameIndex() != null ? cached.nameIndex() : NameIndex.from(index);
+
+        List<String> allNodeIds = new ArrayList<>();
+        List<GrepHit> allGrepHits = new ArrayList<>();
+
+        List<String> strictIds = nameIndex.lookupStrict(qRaw);
+        if (!strictIds.isEmpty()) {
+            Path root = (projectPath != null && !projectPath.isBlank())
+                    ? Paths.get(projectPath).toAbsolutePath().normalize()
+                    : Paths.get(".").toAbsolutePath().normalize();
+            List<String> fileRelPaths = new ArrayList<>();
+            for (Map.Entry<String, AstNode> e : index.entrySet()) {
+                if (e.getKey() != null && e.getKey().startsWith("file:")) {
+                    AstNode n = e.getValue();
+                    String p = n != null ? n.getFilePath() : e.getKey().substring("file:".length());
+                    if (p != null && !p.isBlank()) fileRelPaths.add(p);
+                }
+            }
+            List<GrepHit> grepHits = grepCodeContent(root, fileRelPaths, qRaw, 10);
+            return new SearchCollectResult(strictIds, grepHits);
+        }
+
+        List<String> nameIds = nameIndex.lookup(qRaw);
+        if (!nameIds.isEmpty()) {
+            for (String id : nameIds) {
+                if (!allNodeIds.contains(id)) allNodeIds.add(id);
+            }
+        }
+        if (allNodeIds.size() < SEARCH_MERGE_THRESHOLD) {
+            for (Map.Entry<String, AstNode> e : index.entrySet()) {
+                String id = e.getKey();
+                AstNode n = e.getValue();
+                if (id == null || n == null) continue;
+                String nm = n.getName();
+                String sig = n.getSignature();
+                boolean nameMatch = nm != null && nm.toLowerCase().contains(qLower);
+                boolean sigMatch = sig != null && sig.toLowerCase().contains(qLower);
+                boolean idMatch = id.toLowerCase().contains(qLower);
+                if (!nameMatch && !sigMatch && idMatch && id.startsWith("method:") && id.contains(".")) {
+                    String methodNameInId = id.substring(id.lastIndexOf('.') + 1);
+                    if (!methodNameInId.toLowerCase().contains(qLower)) {
+                        idMatch = false;
+                    }
+                }
+                if (nameMatch || sigMatch || idMatch) {
+                    if (!allNodeIds.contains(id)) allNodeIds.add(id);
+                    if (allNodeIds.size() >= 60) break;
+                }
+                if (id.startsWith("method:")) {
+                    String suffix = id.contains(".") ? id.substring(id.lastIndexOf('.') + 1) : id.substring(Math.max(id.lastIndexOf(':'), 0) + 1);
+                    if (suffix.toLowerCase().contains(qLower) && !allNodeIds.contains(id)) {
+                        allNodeIds.add(id);
+                        if (allNodeIds.size() >= 60) break;
+                    }
+                }
+            }
+        }
+        if (allNodeIds.size() < SEARCH_MERGE_THRESHOLD) {
+            Path root = (projectPath != null && !projectPath.isBlank())
+                    ? Paths.get(projectPath).toAbsolutePath().normalize()
+                    : Paths.get(".").toAbsolutePath().normalize();
+            List<String> fileRelPaths = new ArrayList<>();
+            for (Map.Entry<String, AstNode> e : index.entrySet()) {
+                String id = e.getKey();
+                AstNode n = e.getValue();
+                if (id != null && id.startsWith("file:")) {
+                    String p = n != null ? n.getFilePath() : id.substring("file:".length());
+                    if (p != null && !p.isBlank()) fileRelPaths.add(p);
+                }
+            }
+            List<GrepHit> hits = grepCodeContent(root, fileRelPaths, qRaw, 25);
+            allGrepHits.addAll(hits);
+        }
+        // C1: 当 0 node hits 但 grep 有命中时，从 grep 命中行反查 nodeIndex 提升为节点
+        if (allNodeIds.isEmpty() && !allGrepHits.isEmpty()) {
+            for (GrepHit h : allGrepHits) {
+                String nodeId = findNodeByFileAndLine(index, h.filePath(), h.line());
+                if (nodeId != null && !allNodeIds.contains(nodeId)) {
+                    allNodeIds.add(nodeId);
+                    if (allNodeIds.size() >= 20) break;
+                }
+            }
+        }
+        return new SearchCollectResult(allNodeIds, allGrepHits);
+    }
+
+    /**
+     * C1: 按文件路径与行号在 nodeIndex 中查找包含该行的最小范围节点（method/class/file）。
+     */
+    private String findNodeByFileAndLine(Map<String, AstNode> index, String filePath, int line) {
+        if (index == null || filePath == null || filePath.isBlank() || line < 1) return null;
+        String pathNorm = filePath.replace("\\", "/");
+        int line0 = line - 1;
+        String bestId = null;
+        int bestSpan = Integer.MAX_VALUE;
+        for (Map.Entry<String, AstNode> e : index.entrySet()) {
+            AstNode n = e.getValue();
+            if (n == null) continue;
+            String fp = n.getFilePath();
+            if (fp == null) fp = e.getKey().startsWith("file:") ? e.getKey().substring("file:".length()) : null;
+            if (fp == null || !fp.replace("\\", "/").equals(pathNorm)) continue;
+            int start = n.getStartLine();
+            int end = n.getEndLine();
+            if (line0 >= start && line0 <= end) {
+                int span = end - start + 1;
+                if (span < bestSpan) {
+                    bestSpan = span;
+                    bestId = e.getKey();
+                }
+            }
+        }
+        return bestId;
+    }
+
+    private static final int EXPAND_BATCH_MAX_CHARS = 12_000;
+    private static final int ANALYZE_REPORT_CHARS_PER_KEYWORD = 1_500;
+    private static final int ANALYZE_REPORT_CHARS_CHAIN_BASE = 2_000;
+    private static final int ANALYZE_MAX_REPORT_CHARS_CAP = 15_000;
+    private static final int ANALYZE_MAX_KEYWORDS = 8;
+    private static final int ANALYZE_TOP_EXPAND_PER_KEYWORD = 3;
+    private static final int ANALYZE_MAX_EXPAND_TOTAL = 8;
+    private static final int ANALYZE_MAX_GREP_PER_KEYWORD = 3;
+    private static final int ANALYZE_PREVIEW_LINES = 12;
+    private static final int ANALYZE_MAX_CALL_CHAIN_EDGES = 12;
+
+    /**
+     * 关键词去重：函数名优先、短名优先。函数名仅做精确去重，类名做子串去重，上限8个。避免 aquery_llm 被 query_llm 子串误删。
+     */
+    private String[] deduplicateKeywords(String[] raw) {
+        if (raw == null || raw.length == 0) return raw;
+        List<String> trimmed = new ArrayList<>();
+        for (String s : raw) {
+            String t = s != null ? s.strip() : "";
+            if (t.length() >= 2) trimmed.add(t);
+        }
+        if (trimmed.isEmpty()) return raw;
+        // 函数名优先（含下划线或首字母小写），同类按长度升序
+        trimmed.sort((a, b) -> {
+            boolean aIsFunc = a.contains("_") || (a.length() > 0 && Character.isLowerCase(a.charAt(0)));
+            boolean bIsFunc = b.contains("_") || (b.length() > 0 && Character.isLowerCase(b.charAt(0)));
+            if (aIsFunc != bIsFunc) return aIsFunc ? -1 : 1;
+            return Integer.compare(a.length(), b.length());
+        });
+        List<String> out = new ArrayList<>();
+        for (String candidate : trimmed) {
+            if (out.size() >= ANALYZE_MAX_KEYWORDS) break;
+            String cLower = candidate.toLowerCase();
+            boolean candidateIsFunc = candidate.contains("_") || (candidate.length() > 0 && Character.isLowerCase(candidate.charAt(0)));
+            boolean isDuplicate = false;
+            for (String kept : out) {
+                String kLower = kept.toLowerCase();
+                if (kLower.equals(cLower)) {
+                    isDuplicate = true;
+                    break;
+                }
+                // 仅对类名(PascalCase)做子串去重，函数名不子串去重
+                if (!candidateIsFunc) {
+                    boolean keptIsFunc = kept.contains("_") || (kept.length() > 0 && Character.isLowerCase(kept.charAt(0)));
+                    if (!keptIsFunc && (kLower.contains(cLower) || cLower.contains(kLower))) {
+                        isDuplicate = true;
+                        break;
+                    }
+                }
+            }
+            if (!isDuplicate) out.add(candidate);
+        }
+        return out.toArray(new String[0]);
+    }
+
+    /**
+     * P3 + B1/B2: 一站式分析 — 关键词去重、预搜索、调用链前置、逐关键词输出，动态报告上限。
+     */
+    public String runAnalyze(String projectPath, String[] keywords, String focusPath) {
+        if (projectPath == null || projectPath.isBlank()) {
+            return "✗ 缺少参数 projectPath（项目目录绝对路径）";
+        }
+        if (keywords == null || keywords.length == 0) {
+            return "✗ 缺少参数 keywords（逗号分隔的搜索关键词）";
+        }
+        String[] deduped = deduplicateKeywords(keywords);
+        int reportCharLimit = Math.min(deduped.length * ANALYZE_REPORT_CHARS_PER_KEYWORD + ANALYZE_REPORT_CHARS_CHAIN_BASE, ANALYZE_MAX_REPORT_CHARS_CAP);
+
+        SkeletonCacheService.CachedSkeleton cached = ensureSkeletonCached(projectPath, focusPath);
+        if (cached == null || cached.skeleton() == null) {
+            return "✗ 项目骨架构建失败，请检查 projectPath 与 focusPath";
+        }
+        ProjectSkeleton sk = cached.skeleton();
+        Map<String, AstNode> index = cached.graph() != null ? cached.graph().getNodeIndex() : Map.of();
+        Path root = Paths.get(projectPath).toAbsolutePath().normalize();
+
+        String projectName = projectPath.replace("\\", "/");
+        if (projectName.contains("/")) projectName = projectName.substring(projectName.lastIndexOf('/') + 1);
+
+        Set<String> prevKeywords = skeletonCacheService.getAnalyzedKeywords(projectPath);
+        boolean isIncremental = prevKeywords != null && !prevKeywords.isEmpty();
+
+        // B2: 预搜索收集所有关键词的 nodeIds 与每关键词结果
+        Set<String> allKeywordNodeIds = new LinkedHashSet<>();
+        List<SearchCollectResult> resultsPerKeyword = new ArrayList<>();
+        List<String> searchedKeywords = new ArrayList<>();
+        for (String kw : deduped) {
+            String q = kw != null ? kw.strip() : "";
+            if (q.length() < 2) continue;
+            SearchCollectResult col = runSingleSearchCollecting(cached, projectPath, q);
+            resultsPerKeyword.add(col);
+            searchedKeywords.add(q);
+            allKeywordNodeIds.addAll(col.nodeIds());
+        }
+
+        StringBuilder header = new StringBuilder();
+        if (isIncremental) {
+            // B3: 增量模式不重复输出项目统计，改为精简头
+            List<String> newlyAdded = searchedKeywords.stream().filter(k -> !prevKeywords.contains(k)).toList();
+
+            // opt-a: 全命中缓存场景 - 直接返回单行摘要，避免逐关键词输出 [cached summary]
+            if (newlyAdded.isEmpty()) {
+                skeletonCacheService.recordAnalyzedKeywords(projectPath, searchedKeywords);
+                return "## " + projectName + " (incremental)\n"
+                        + "All " + searchedKeywords.size() + " keywords already analyzed: "
+                        + String.join(", ", searchedKeywords) + "\n"
+                        + "Use exploreCodeContext(mode=expand) to read code directly.\n\n"
+                        + "---\n"
+                        + "Tip: 可用 exploreCodeContext(mode=expand, query=\"file:start-end\") 读取完整代码（支持批量: file1:range|file2:range），减少 Cursor Read。\n";
+            }
+
+            header.append("## ").append(projectName).append(" (incremental)\n");
+            header.append("Previously analyzed: ").append(String.join(", ", prevKeywords)).append("\n");
+            header.append("New in this call: ").append(String.join(", ", newlyAdded)).append("\n\n");
+        } else {
+            // B1: 首次调用输出项目统计，但去掉无意义的 Files 行
+            header.append("## ").append(projectName)
+                    .append(" (").append(sk.getTotalFiles()).append(" files, ")
+                    .append(sk.getTotalClasses()).append(" classes, ")
+                    .append(sk.getTotalMethods()).append(" methods)\n\n");
+        }
+
+        // 调用链：优先 AST invokes 边，为空时用 grep 交叉引用推断
+        Map<String, Set<String>> callGraphFromGrep = buildCallGraphFromGrep(projectPath, root, index, resultsPerKeyword, searchedKeywords);
+        String chainSection = buildCallChainsSection(cached, allKeywordNodeIds);
+        if (chainSection == null || chainSection.isBlank()) {
+            chainSection = buildChainLinesFromGraph(callGraphFromGrep, searchedKeywords);
+        }
+        String summarySection = buildSummarySection(callGraphFromGrep, searchedKeywords, resultsPerKeyword, index, chainSection);
+        String summaryBlock = (summarySection != null && !summarySection.isBlank())
+                ? ("### Summary\n" + summarySection + "\n\n")
+                : "";
+        String chainBlock = (chainSection != null && !chainSection.isBlank())
+                ? ("### Call Flow\n" + chainSection + "\n\n")
+                : "";
+
+        // 按调用深度排序关键词（入口在前），便于 LLM 直接理解流程
+        List<String> orderedKeywords = topologicalSortKeywords(callGraphFromGrep, searchedKeywords);
+
+        final int headerBudget = 500;
+        final int summaryBudget = 800;
+        final int chainBudget = 1_200;
+        final String footer = "---\n"
+                + "Tip: 可用 exploreCodeContext(mode=expand, query=\"file:start-end\") 读取完整代码（支持批量: file1:range|file2:range），减少 Cursor Read。\n";
+        final int footerBudget = Math.min(280, footer.length());
+
+        int remaining = reportCharLimit;
+        StringBuilder report = new StringBuilder(Math.min(reportCharLimit + 200, ANALYZE_MAX_REPORT_CHARS_CAP + 400));
+
+        String headerBlock = header.toString();
+        if (headerBlock.length() > headerBudget) headerBlock = headerBlock.substring(0, headerBudget);
+        report.append(headerBlock);
+        remaining -= headerBlock.length();
+
+        if (remaining > 0 && !summaryBlock.isBlank()) {
+            String s = summaryBlock;
+            if (s.length() > summaryBudget) s = s.substring(0, summaryBudget);
+            if (s.length() > remaining) s = s.substring(0, remaining);
+            report.append(s);
+            remaining -= s.length();
+        }
+
+        if (remaining > 0 && !chainBlock.isBlank()) {
+            String c = chainBlock;
+            if (c.length() > chainBudget) c = c.substring(0, chainBudget);
+            if (c.length() > remaining) c = c.substring(0, remaining);
+            report.append(c);
+            remaining -= c.length();
+        }
+
+        int kwCount = Math.max(1, orderedKeywords.size());
+        int kwTotalBudget = Math.max(0, remaining - footerBudget);
+        int perKwBudget = kwTotalBudget / kwCount;
+
+        Set<String> expandedIds = new LinkedHashSet<>();
+        for (String q : orderedKeywords) {
+            if (remaining <= footerBudget) break;
+
+            int idx = searchedKeywords.indexOf(q);
+            if (idx < 0 || idx >= resultsPerKeyword.size()) continue;
+            SearchCollectResult col = resultsPerKeyword.get(idx);
+
+            StringBuilder kw = new StringBuilder();
+            if (isIncremental && prevKeywords.contains(q)) {
+                kw.append("### ").append(q).append(" [cached summary]\n");
+                int shown = 0;
+                for (String nodeId : col.nodeIds()) {
+                    String loc = renderAnalyzeNodeLocator(nodeId, index);
+                    if (loc != null && !loc.isBlank()) {
+                        kw.append(loc).append("\n");
+                        if (++shown >= 2) break;
+                    }
+                }
+                if (shown == 0) {
+                    kw.append("(no nodes)\n");
+                }
+                kw.append("\n");
+                String kwStr = kw.toString();
+                if (kwStr.length() > remaining - footerBudget) kwStr = kwStr.substring(0, Math.max(0, remaining - footerBudget));
+                report.append(kwStr);
+                remaining -= kwStr.length();
+                continue;
+            }
+
+            kw.append("### ").append(q).append(" (").append(col.nodeIds().size()).append(" node hits, ")
+                    .append(col.grepHits().size()).append(" grep)\n");
+
+            int taken = 0;
+            for (String nodeId : col.nodeIds()) {
+                if (taken >= ANALYZE_TOP_EXPAND_PER_KEYWORD) break;
+                if (expandedIds.size() >= ANALYZE_MAX_EXPAND_TOTAL) break;
+                if (!expandedIds.add(nodeId)) continue;
+                String preview = renderAnalyzeNodePreview(projectPath, root, nodeId, index, cached.graph(), ANALYZE_PREVIEW_LINES);
+                if (preview != null && !preview.isBlank()) {
+                    kw.append(preview).append("\n");
+                    taken++;
+                }
+            }
+            int grepShown = 0;
+            if (col.nodeIds().isEmpty()) {
+                for (GrepHit h : col.grepHits()) {
+                    if (grepShown >= ANALYZE_MAX_GREP_PER_KEYWORD) break;
+                    // D2: grep 结果增加函数/类上下文
+                    String ctx = "";
+                    String hitNodeId = findNodeByFileAndLine(index, h.filePath(), h.line());
+                    if (hitNodeId != null) {
+                        AstNode n = index.get(hitNodeId);
+                        if (n != null && n.getName() != null && !n.getName().isBlank())
+                            ctx = "in " + n.getName() + " | ";
+                    }
+                    String snippet = h.snippet().length() > 200 ? h.snippet().substring(0, 197) + "..." : h.snippet();
+                    kw.append("[grep] ").append(h.filePath()).append(":").append(h.line())
+                            .append(" | ").append(ctx).append(snippet).append("\n");
+                    grepShown++;
+                }
+            }
+            kw.append("\n");
+
+            String kwStr = kw.toString();
+            int budget = Math.min(perKwBudget, remaining - footerBudget);
+            if (budget > 0 && kwStr.length() > budget) {
+                String suffix = "\n... [" + q + " 截断, 用 exploreCodeContext(mode=expand) 查看完整代码]\n\n";
+                int keep = Math.max(0, budget - suffix.length());
+                kwStr = kwStr.substring(0, Math.min(keep, kwStr.length())) + suffix;
+            }
+            if (kwStr.length() > remaining - footerBudget) kwStr = kwStr.substring(0, Math.max(0, remaining - footerBudget));
+            report.append(kwStr);
+            remaining -= kwStr.length();
+        }
+
+        if (remaining > 0) {
+            String f = footer;
+            if (f.length() > remaining) f = f.substring(0, remaining);
+            report.append(f);
+            remaining -= f.length();
+        }
+
+        skeletonCacheService.recordAnalyzedKeywords(projectPath, searchedKeywords);
+
+        String out = report.toString().trim();
+        if (out.length() > reportCharLimit) {
+            out = out.substring(0, reportCharLimit) + "\n\n... [报告已截断至 " + reportCharLimit + " 字符]";
+        }
+        return out;
+    }
+
+    private static String renderAnalyzeNodeLocator(String nodeId, Map<String, AstNode> index) {
+        if (nodeId == null || index == null) return null;
+        AstNode node = index.get(nodeId);
+        if (node == null) return null;
+        String kind = nodeId.startsWith("file:") ? "file" : (nodeId.startsWith("class:") ? "class" : (nodeId.startsWith("method:") ? "method" : "node"));
+        String name = node.getName() != null ? node.getName() : nodeId;
+        String fp = node.getFilePath();
+        int start = node.getStartLine() + 1;
+        int end = node.getEndLine() + 1;
+        StringBuilder sb = new StringBuilder();
+        sb.append("- [").append(kind).append("] ").append(name);
+        if (fp != null && !fp.isBlank() && start > 0) {
+            sb.append(" -- ").append(fp.replace("\\", "/")).append(":").append(start);
+            if (end > start) sb.append("-").append(end);
+        }
+        return sb.toString();
+    }
+
+    private String renderAnalyzeNodePreview(String projectPath, Path root, String nodeId, Map<String, AstNode> index, DependencyGraph graph, int maxLines) {
+        AstNode node = index.get(nodeId);
+        if (node == null) return null;
+        String kind = nodeId.startsWith("file:") ? "file" : (nodeId.startsWith("class:") ? "class" : (nodeId.startsWith("method:") ? "method" : "node"));
+        String name = node.getName() != null ? node.getName() : nodeId;
+        String fp = node.getFilePath();
+        int line = node.getStartLine() + 1;
+        StringBuilder sb = new StringBuilder();
+        sb.append("[").append(kind).append("] ").append(name);
+        if (fp != null && !fp.isBlank()) {
+            sb.append(" -- ").append(fp.replace("\\", "/"));
+            if (line > 0) {
+                sb.append(":").append(line);
+                int endLine = node.getEndLine() + 1;
+                if (endLine > line) {
+                    sb.append("-").append(endLine)
+                            .append(" (").append(endLine - line + 1).append(" lines)");
+                }
+            }
+        }
+        sb.append("\n");
+        if ("method".equals(kind) || "class".equals(kind)) {
+            String sig = compactOneLine(node.getSignature(), node.getNodeType() + " " + name);
+            if (sig != null && !sig.isBlank()) {
+                sb.append("  ").append(sig).append("\n");
+            }
+            String code = extractCodePreview(projectPath, node, maxLines);
+            if (code != null && !code.isBlank()) {
+                for (String l : code.split("\n")) {
+                    sb.append("  ").append(l).append("\n");
+                }
+            }
+        }
+        if (graph != null && graph.getGraph() != null && graph.getGraph().containsVertex(nodeId)) {
+            List<String> refs = getTopReferencedBy(nodeId, graph, index, 3);
+            if (!refs.isEmpty()) {
+                sb.append("  ← referenced by: ").append(String.join(", ", refs)).append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    private static final int ANALYZE_CALL_CHAIN_MAX_DEPTH = 5;
+
+    /**
+     * 调用链：仅沿 invokes 边 BFS，生成 "A -> B -> C" 格式。不含 contains/class->method。
+     */
+    private String buildCallChainsSection(SkeletonCacheService.CachedSkeleton cached, Set<String> nodeIds) {
+        DependencyGraph graph = cached.graph();
+        if (graph == null || graph.getGraph() == null || nodeIds == null || nodeIds.isEmpty()) return "";
+        DefaultDirectedWeightedGraph<String, DefaultWeightedEdge> g = graph.getGraph();
+        Map<String, AstNode> index = graph.getNodeIndex();
+        List<String> lines = new ArrayList<>();
+        int totalEdges = 0;
+        Set<String> seenChains = new HashSet<>();
+        for (String start : nodeIds) {
+            if (!g.containsVertex(start) || totalEdges >= ANALYZE_MAX_CALL_CHAIN_EDGES) break;
+            Deque<String> queue = new ArrayDeque<>();
+            Deque<List<String>> pathQueue = new ArrayDeque<>();
+            queue.add(start);
+            pathQueue.add(new ArrayList<>(List.of(start)));
+            Set<String> visited = new HashSet<>();
+            visited.add(start);
+            while (!queue.isEmpty() && totalEdges < ANALYZE_MAX_CALL_CHAIN_EDGES) {
+                String v = queue.poll();
+                List<String> path = pathQueue.poll();
+                if (path == null || path.size() > ANALYZE_CALL_CHAIN_MAX_DEPTH) continue;
+                for (DefaultWeightedEdge e : g.outgoingEdgesOf(v)) {
+                    String t = g.getEdgeTarget(e);
+                    String et = graph.getEdgeType(v, t);
+                    if (!"invokes".equals(et)) continue;
+                    if (visited.contains(t)) continue;
+                    visited.add(t);
+                    List<String> newPath = new ArrayList<>(path);
+                    newPath.add(t);
+                    queue.add(t);
+                    pathQueue.add(newPath);
+                    String chainKey = String.join("->", newPath);
+                    if (seenChains.add(chainKey)) {
+                        String chainLine = newPath.stream()
+                                .map(id -> prettyNodeLabel(id, index))
+                                .reduce((a, b) -> a + " -> " + b)
+                                .orElse("");
+                        if (!chainLine.isBlank()) {
+                            lines.add(chainLine);
+                            totalEdges++;
+                        }
+                    }
+                }
+            }
+        }
+        if (lines.isEmpty()) {
+            // 回退: 仅输出 invokes 直接边
+            for (String v : nodeIds) {
+                if (!g.containsVertex(v) || totalEdges >= ANALYZE_MAX_CALL_CHAIN_EDGES) break;
+                for (DefaultWeightedEdge e : g.outgoingEdgesOf(v)) {
+                    if (totalEdges >= ANALYZE_MAX_CALL_CHAIN_EDGES) break;
+                    String t = g.getEdgeTarget(e);
+                    String et = graph.getEdgeType(v, t);
+                    if ("invokes".equals(et)) {
+                        lines.add(prettyNodeLabel(v, index) + " -> " + prettyNodeLabel(t, index));
+                        totalEdges++;
+                    }
+                }
+            }
+        }
+        return lines.isEmpty() ? "" : String.join("\n", lines);
+    }
+
+    /**
+     * 从各关键词的代码预览与 grep 命中中交叉推断调用图：若 A 的代码中出现 B( 或 await B，则 A 调用 B。
+     */
+    private Map<String, Set<String>> buildCallGraphFromGrep(String projectPath, Path root, Map<String, AstNode> index,
+                                                             List<SearchCollectResult> resultsPerKeyword, List<String> searchedKeywords) {
+        Map<String, Set<String>> callGraph = new LinkedHashMap<>();
+        if (resultsPerKeyword == null || searchedKeywords == null || resultsPerKeyword.size() != searchedKeywords.size()) return callGraph;
+        for (int i = 0; i < searchedKeywords.size(); i++) {
+            SearchCollectResult col = resultsPerKeyword.get(i);
+            String callerCode = collectFullMethodBodyForInference(projectPath, root, index, col);
+            if (callerCode == null || callerCode.isBlank()) continue;
+            Set<String> callees = new LinkedHashSet<>();
+            for (int j = 0; j < searchedKeywords.size(); j++) {
+                if (i == j) continue;
+                String callee = searchedKeywords.get(j);
+                if (callerCode.contains(callee + "(") || callerCode.contains(callee + " (")
+                        || callerCode.contains("await " + callee + "(") || callerCode.contains("await " + callee + " (")) {
+                    callees.add(callee);
+                }
+            }
+            if (!callees.isEmpty()) callGraph.put(searchedKeywords.get(i), callees);
+        }
+        return callGraph;
+    }
+
+    /**
+     * 生成自足摘要：入口函数及位置 + 调用流前几行，便于 LLM 直接引用。
+     * Entry = 调用其他关键词最多的关键词（出度最高），而非"没被调用的关键词"。
+     * 这样避免 PGGraphStorage（出度=0）被误选为入口，而 aquery_llm（出度=3）才是真正入口。
+     */
+    private String buildSummarySection(Map<String, Set<String>> callGraph, List<String> searchedKeywords,
+                                       List<SearchCollectResult> resultsPerKeyword, Map<String, AstNode> index,
+                                       String chainSection) {
+        Map<String, Integer> outDeg = new LinkedHashMap<>();
+        for (String k : searchedKeywords) outDeg.put(k, 0);
+        if (callGraph != null) {
+            for (Map.Entry<String, Set<String>> e : callGraph.entrySet()) {
+                outDeg.put(e.getKey(), e.getValue().size());
+            }
+        }
+        List<String> callers = searchedKeywords.stream()
+                .filter(k -> outDeg.getOrDefault(k, 0) > 0)
+                .sorted((a, b) -> {
+                    int cmp = Integer.compare(outDeg.getOrDefault(b, 0), outDeg.getOrDefault(a, 0));
+                    if (cmp != 0) return cmp;
+                    return Integer.compare(searchedKeywords.indexOf(a), searchedKeywords.indexOf(b));
+                })
+                .toList();
+        List<String> entries = callers.isEmpty() ? searchedKeywords : callers;
+        if (entries.isEmpty()) return null;
+        StringBuilder sb = new StringBuilder();
+        for (int e = 0; e < Math.min(3, entries.size()); e++) {
+            String kw = entries.get(e);
+            int idx = searchedKeywords.indexOf(kw);
+            if (idx < 0 || idx >= resultsPerKeyword.size()) continue;
+            SearchCollectResult col = resultsPerKeyword.get(idx);
+            if (!col.nodeIds().isEmpty()) {
+                AstNode n = index.get(col.nodeIds().get(0));
+                if (n != null && n.getFilePath() != null) {
+                    String fp = n.getFilePath().replace("\\", "/");
+                    int line = n.getStartLine() + 1;
+                    if (sb.length() > 0) sb.append(" ");
+                    sb.append(kw).append(" (").append(fp).append(":").append(line).append(")");
+                }
+            }
+        }
+        if (sb.length() > 0) sb.insert(0, "Entry: ");
+        if (chainSection != null && !chainSection.isBlank()) {
+            String firstLine = chainSection.contains("\n") ? chainSection.substring(0, chainSection.indexOf('\n')) : chainSection;
+            if (firstLine.length() > 120) firstLine = firstLine.substring(0, 117) + "...";
+            sb.append("\nFlow: ").append(firstLine);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * 按出度降序排列（调用其他关键词最多的在前），而非纯拓扑排序。
+     * 互相调用时（aquery_llm ↔ query_llm）不会死锁，出度高的排前面。
+     */
+    private List<String> topologicalSortKeywords(Map<String, Set<String>> callGraph, List<String> keywords) {
+        if (keywords == null || keywords.isEmpty()) return List.of();
+        Map<String, Integer> outDeg = new HashMap<>();
+        Map<String, Integer> inDeg = new HashMap<>();
+        for (String k : keywords) { outDeg.put(k, 0); inDeg.put(k, 0); }
+        if (callGraph != null) {
+            for (Map.Entry<String, Set<String>> e : callGraph.entrySet()) {
+                outDeg.merge(e.getKey(), e.getValue().size(), Integer::sum);
+                for (String callee : e.getValue()) inDeg.merge(callee, 1, Integer::sum);
+            }
+        }
+        List<String> order = new ArrayList<>(keywords);
+        order.sort((a, b) -> {
+            int netA = outDeg.getOrDefault(a, 0) - inDeg.getOrDefault(a, 0);
+            int netB = outDeg.getOrDefault(b, 0) - inDeg.getOrDefault(b, 0);
+            if (netA != netB) return Integer.compare(netB, netA);
+            int outA = outDeg.getOrDefault(a, 0);
+            int outB = outDeg.getOrDefault(b, 0);
+            if (outA != outB) return Integer.compare(outB, outA);
+            return Integer.compare(keywords.indexOf(a), keywords.indexOf(b));
+        });
+        return order;
+    }
+
+    private String collectCodeTextForResult(SearchCollectResult col, String projectPath, Path root, Map<String, AstNode> index) {
+        StringBuilder sb = new StringBuilder();
+        int nodeLimit = Math.min(col.nodeIds().size(), ANALYZE_TOP_EXPAND_PER_KEYWORD);
+        for (int i = 0; i < nodeLimit; i++) {
+            String preview = renderAnalyzeNodePreview(projectPath, root, col.nodeIds().get(i), index, null, ANALYZE_PREVIEW_LINES);
+            if (preview != null) sb.append(preview);
+        }
+        for (GrepHit h : col.grepHits()) {
+            if (h.snippet() != null) sb.append(h.snippet()).append("\n");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * 专供调用图推断：读取每个 method 节点的完整函数体（startLine 到 endLine），以便检测体内的 callee 调用。
+     */
+    private String collectFullMethodBodyForInference(String projectPath, Path root, Map<String, AstNode> index, SearchCollectResult col) {
+        StringBuilder sb = new StringBuilder();
+        for (String nodeId : col.nodeIds()) {
+            if (!nodeId.startsWith("method:")) continue;
+            AstNode node = index.get(nodeId);
+            if (node == null || node.getFilePath() == null) continue;
+            Path file = root.resolve(node.getFilePath().replace("\\", "/"));
+            if (!Files.isRegularFile(file)) continue;
+            try {
+                List<String> lines = Files.readAllLines(file, StandardCharsets.UTF_8);
+                int start = Math.max(0, node.getStartLine());
+                int end = Math.min(lines.size() - 1, node.getEndLine());
+                for (int i = start; i <= end; i++) {
+                    sb.append(lines.get(i)).append("\n");
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        for (GrepHit h : col.grepHits()) {
+            if (h.snippet() != null) sb.append(h.snippet()).append("\n");
+        }
+        return sb.toString();
+    }
+
+    private String buildChainLinesFromGraph(Map<String, Set<String>> callGraph, List<String> keywords) {
+        if (callGraph.isEmpty()) return "";
+        Set<String> calleeSet = new HashSet<>();
+        for (Set<String> callees : callGraph.values()) calleeSet.addAll(callees);
+        List<String> entries = keywords.stream().filter(k -> !calleeSet.contains(k)).toList();
+        List<String> lines = new ArrayList<>();
+        int maxDepth = 5;
+        int maxLines = 12;
+        for (String entry : entries) {
+            if (lines.size() >= maxLines) break;
+            Deque<List<String>> pathStack = new ArrayDeque<>();
+            pathStack.add(new ArrayList<>(List.of(entry)));
+            while (!pathStack.isEmpty() && lines.size() < maxLines) {
+                List<String> path = pathStack.poll();
+                if (path.size() > maxDepth) continue;
+                String last = path.get(path.size() - 1);
+                Set<String> nexts = callGraph.get(last);
+                if (nexts == null || nexts.isEmpty()) {
+                    if (path.size() >= 2) lines.add(String.join(" -> ", path));
+                    continue;
+                }
+                for (String next : nexts) {
+                    if (path.contains(next)) continue;
+                    List<String> newPath = new ArrayList<>(path);
+                    newPath.add(next);
+                    pathStack.add(newPath);
+                }
+            }
+        }
+        if (lines.isEmpty()) {
+            for (Map.Entry<String, Set<String>> e : callGraph.entrySet()) {
+                for (String t : e.getValue()) lines.add(e.getKey() + " -> " + t);
+                if (lines.size() >= maxLines) break;
+            }
+        }
+        return String.join("\n", lines);
+    }
+
     private String runTrace(SkeletonCacheService.CachedSkeleton cached, String query, String direction, int maxDepth) {
         if (query == null || query.isBlank()) return "✗ trace 模式需要提供 query（类名或方法名）。";
         DependencyGraph graph = cached.graph();
@@ -915,10 +1643,11 @@ public class CodestyleService {
             if ("both".equals(direction) || "downstream".equals(direction)) {
                 for (DefaultWeightedEdge e : g.outgoingEdgesOf(v)) {
                     String t = g.getEdgeTarget(e);
+                    String et = graph.getEdgeType(v, t);
+                    if ("contains".equals(et)) continue;
                     if (visited.add(t)) {
                         depthMap.put(t, d + 1);
                         queue.add(t);
-                        String et = graph.getEdgeType(v, t);
                         if (et == null || et.isBlank()) et = "depends";
                         lines.add("  ".repeat(d + 1) + "→ [" + et + "] " + prettyNodeLabel(t, index));
                     }
@@ -927,10 +1656,11 @@ public class CodestyleService {
             if ("both".equals(direction) || "upstream".equals(direction)) {
                 for (DefaultWeightedEdge e : g.incomingEdgesOf(v)) {
                     String s = g.getEdgeSource(e);
+                    String et = graph.getEdgeType(s, v);
+                    if ("contains".equals(et)) continue;
                     if (visited.add(s)) {
                         depthMap.put(s, d + 1);
                         queue.add(s);
-                        String et = graph.getEdgeType(s, v);
                         if (et == null || et.isBlank()) et = "depends";
                         lines.add("  ".repeat(d + 1) + "← [" + et + "] " + prettyNodeLabel(s, index));
                     }
@@ -1008,7 +1738,7 @@ public class CodestyleService {
         // Step 1: 精确匹配（nodeId / name 精确）— 命中则直接返回
         List<String> strictIds = nameIndex.lookupStrict(qRaw);
         if (!strictIds.isEmpty()) {
-            return renderSearchResult(projectPath, qRaw, "strict", strictIds, index, List.of());
+            return renderSearchResult(projectPath, qRaw, "strict", strictIds, index, List.of(), cached.graph());
         }
 
         List<String> allNodeIds = new ArrayList<>();
@@ -1033,9 +1763,16 @@ public class CodestyleService {
                 if (id == null || n == null) continue;
                 String nm = n.getName();
                 String sig = n.getSignature();
-                if ((nm != null && nm.toLowerCase().contains(qLower)) ||
-                        (sig != null && sig.toLowerCase().contains(qLower)) ||
-                        id.toLowerCase().contains(qLower)) {
+                boolean nameMatch = nm != null && nm.toLowerCase().contains(qLower);
+                boolean sigMatch = sig != null && sig.toLowerCase().contains(qLower);
+                boolean idMatch = id.toLowerCase().contains(qLower);
+                if (!nameMatch && !sigMatch && idMatch && id.startsWith("method:") && id.contains(".")) {
+                    String methodNameInId = id.substring(id.lastIndexOf('.') + 1);
+                    if (!methodNameInId.toLowerCase().contains(qLower)) {
+                        idMatch = false;
+                    }
+                }
+                if (nameMatch || sigMatch || idMatch) {
                     if (!allNodeIds.contains(id)) astIds.add(id);
                     if (astIds.size() + allNodeIds.size() >= 60) break;
                 }
@@ -1066,7 +1803,7 @@ public class CodestyleService {
         }
 
         if (!allNodeIds.isEmpty() || !allGrepHits.isEmpty()) {
-            return renderSearchResult(projectPath, qRaw, bestStage, allNodeIds, index, allGrepHits);
+            return renderSearchResult(projectPath, qRaw, bestStage, allNodeIds, index, allGrepHits, cached.graph());
         }
 
         // Step 5: 轻量模糊匹配候选（token Jaccard）
@@ -1181,6 +1918,123 @@ public class CodestyleService {
         return out;
     }
 
+    private String buildCacheHitSummary(SkeletonCacheService.CachedSkeleton cached, ProjectSkeleton sk, String projectPath) {
+        int files = sk.getTotalFiles();
+        int classes = sk.getTotalClasses();
+        int methods = sk.getTotalMethods();
+        long ageSec = (System.currentTimeMillis() - cached.buildTime()) / 1000;
+        StringBuilder sb = new StringBuilder();
+        sb.append("[cached] 骨架已缓存 (").append(files).append("文件/").append(classes).append("类/").append(methods).append("方法, ")
+          .append(String.format("%.0f", (double) ageSec)).append("秒前构建)\n");
+        sb.append("核心类:\n");
+        Path root = (projectPath != null && !projectPath.isBlank())
+                ? Paths.get(projectPath).toAbsolutePath().normalize() : null;
+        int classCount = 0;
+        final int maxClasses = 8;
+        final int maxMethodsPerClass = 5;
+        List<AstNode> fileNodes = sk.getFileNodes() != null ? sk.getFileNodes() : List.of();
+        for (AstNode fileNode : fileNodes) {
+            if (classCount >= maxClasses) break;
+            if (fileNode.getChildren() == null) continue;
+            String relPath = fileNode.getFilePath();
+            if (relPath == null) relPath = "";
+            for (AstNode child : fileNode.getChildren()) {
+                if (classCount >= maxClasses) break;
+                String nt = child.getNodeType();
+                if (nt == null) continue;
+                String ntLower = nt.toLowerCase();
+                if (!"class".equals(ntLower) && !"interface".equals(ntLower) && !"enum".equals(ntLower)) continue;
+                String className = DependencyGraphBuilder.extractSimpleName(child.getName(), nt);
+                if (className == null || className.isBlank()) className = child.getName();
+                if (className == null) className = "(unnamed)";
+                int line = child.getStartLine() + 1;
+                sb.append("  ").append(className).append(" (").append(relPath.replace("\\", "/")).append(":").append(line).append(") — ");
+                List<String> methodNames = new ArrayList<>();
+                if (child.getChildren() != null) {
+                    for (AstNode m : child.getChildren()) {
+                        if (methodNames.size() >= maxMethodsPerClass) break;
+                        if (m != null && "method".equals(m.getNodeType())) {
+                            String mn = DependencyGraphBuilder.extractSimpleName(m.getName(), "method");
+                            if (mn != null && !mn.isBlank()) methodNames.add(mn);
+                        }
+                    }
+                }
+                sb.append(methodNames.isEmpty() ? "..." : String.join(", ", methodNames)).append("\n");
+                classCount++;
+            }
+        }
+        if (classCount == 0) sb.append("  (无)\n");
+        sb.append("文件: ");
+        List<String> fileEntries = new ArrayList<>();
+        int fileShown = 0;
+        for (AstNode fileNode : fileNodes) {
+            if (fileShown >= 8) break;
+            String relPath = fileNode.getFilePath();
+            if (relPath == null || relPath.isBlank()) continue;
+            String base = relPath.replace("\\", "/");
+            if (base.contains("/")) base = base.substring(base.lastIndexOf('/') + 1);
+            int lineCount = -1;
+            if (root != null) {
+                Path abs = resolveProjectFile(root, relPath);
+                if (abs != null) {
+                    try {
+                        lineCount = Files.readAllLines(abs, StandardCharsets.UTF_8).size();
+                    } catch (Exception ignored) { }
+                }
+            }
+            fileEntries.add(lineCount >= 0 ? base + "(" + lineCount + "行)" : base);
+            fileShown++;
+        }
+        sb.append(fileEntries.isEmpty() ? "(无)" : String.join(", ", fileEntries)).append("\n");
+        DependencyGraph graph = cached.graph();
+        if (graph != null && graph.getEdgeTypeIndex() != null && !graph.getEdgeTypeIndex().isEmpty()) {
+            Map<String, AstNode> index = graph.getNodeIndex();
+            List<String> depLines = new ArrayList<>();
+            for (Map.Entry<String, String> e : graph.getEdgeTypeIndex().entrySet()) {
+                if ("contains".equals(e.getValue())) continue;
+                if (depLines.size() >= 5) break;
+                String key = e.getKey();
+                int pipe = key != null ? key.indexOf('|') : -1;
+                String src = (pipe > 0 && key != null) ? key.substring(0, pipe) : key;
+                String tgt = (pipe >= 0 && key != null && pipe < key.length() - 1) ? key.substring(pipe + 1) : "";
+                String srcLabel = shortVertexLabel(src, index);
+                String tgtLabel = shortVertexLabel(tgt, index);
+                depLines.add(srcLabel + "→" + tgtLabel + "(" + e.getValue() + ")");
+            }
+            if (!depLines.isEmpty()) {
+                sb.append("依赖: ").append(String.join(", ", depLines)).append("\n");
+            }
+        }
+        List<SkeletonCacheService.ExploredEntry> history = skeletonCacheService.getExploreHistory(projectPath);
+        if (!history.isEmpty()) {
+            sb.append("--- 已探索 ---\n");
+            int shown = 0;
+            for (SkeletonCacheService.ExploredEntry entry : history) {
+                long agoSec = (System.currentTimeMillis() - entry.timestamp()) / 1000;
+                sb.append(entry.mode()).append("(\"").append(entry.query()).append("\") → ")
+                  .append(entry.hitCount()).append(" hits (").append(agoSec).append("秒前)\n");
+                if (++shown >= 8) break;
+            }
+        }
+        sb.append("--- 查询示例 ---\n");
+        sb.append("search(\"类名\") | expand(\"文件路径\") | expand(\"类名\") | trace(\"类名\")\n");
+        sb.append("expand 支持 lineRange 参数精确定位，如 lineRange=\"100-200\"。如需重新解析请传 forceRefresh=true");
+        return sb.toString();
+    }
+
+    private static String shortVertexLabel(String vertexId, Map<String, AstNode> index) {
+        if (vertexId == null || vertexId.isBlank()) return vertexId;
+        if (index != null) {
+            AstNode n = index.get(vertexId);
+            if (n != null && n.getName() != null && !n.getName().isBlank())
+                return n.getName();
+        }
+        if (vertexId.startsWith("file:")) return vertexId.length() > 5 ? vertexId.substring(5).replace("\\", "/") : vertexId;
+        if (vertexId.startsWith("class:") && vertexId.contains(":")) return vertexId.substring(vertexId.lastIndexOf(':') + 1);
+        if (vertexId.startsWith("method:") && vertexId.contains(".")) return vertexId.substring(vertexId.lastIndexOf('.') + 1);
+        return vertexId;
+    }
+
     private record GrepHit(String filePath, int line, String snippet) {}
 
     private List<GrepHit> grepCodeContent(Path projectRoot, List<String> fileRelPaths, String query, int maxHits) {
@@ -1217,8 +2071,31 @@ public class CodestyleService {
         return hits;
     }
 
-    private static String renderSearchResult(String projectPath, String query, String stage, List<String> nodeIds,
-                                            Map<String, AstNode> index, List<GrepHit> grepHits) {
+    private static List<String> getTopReferencedBy(String nodeId, DependencyGraph graph,
+            Map<String, AstNode> index, int max) {
+        if (graph == null || graph.getGraph() == null || nodeId == null) return List.of();
+        var g = graph.getGraph();
+        if (!g.containsVertex(nodeId)) return List.of();
+        List<String> refs = new ArrayList<>();
+        for (var e : g.incomingEdgesOf(nodeId)) {
+            String src = g.getEdgeSource(e);
+            String et = graph.getEdgeType(src, nodeId);
+            if ("contains".equals(et)) continue;
+            AstNode n = index != null ? index.get(src) : null;
+            String label = (n != null && n.getName() != null) ? n.getName() : src;
+            String fp = (n != null && n.getFilePath() != null) ? n.getFilePath().replace("\\", "/") : "";
+            int line = (n != null) ? n.getStartLine() + 1 : -1;
+            String ref = label;
+            if (!fp.isEmpty()) ref += " (" + fp + (line > 0 ? ":" + line : "") + ")";
+            refs.add(ref);
+            if (refs.size() >= max) break;
+        }
+        return refs;
+    }
+
+    private String renderSearchResult(String projectPath, String query, String stage, List<String> nodeIds,
+                                            Map<String, AstNode> index, List<GrepHit> grepHits,
+                                            DependencyGraph graph) {
         List<String> uniqueIds = nodeIds != null ? new ArrayList<>(new LinkedHashSet<>(nodeIds)) : List.of();
         int nodeCount = uniqueIds.size();
         int grepCount = grepHits != null ? grepHits.size() : 0;
@@ -1290,6 +2167,13 @@ public class CodestyleService {
                     }
                 }
 
+                if (graph != null && graph.getGraph() != null && graph.getGraph().containsVertex(id)) {
+                    List<String> refs = getTopReferencedBy(id, graph, index, 3);
+                    if (!refs.isEmpty()) {
+                        sb.append("  ← referenced by: ").append(String.join(", ", refs)).append("\n");
+                    }
+                }
+
                 written++;
                 if (written >= 30) break;
             }
@@ -1310,7 +2194,7 @@ public class CodestyleService {
     }
 
     /**
-     * 从源文件读取节点处 3-5 行代码预览（跳过空行和纯注释），用于 search 结果内嵌，减少 expand 调用。
+     * 从源文件读取节点处代码预览。对 method/function 节点跳过签名参数列表，从函数体第一行开始取 maxLines 行，便于看到调用关系。
      */
     private static String extractCodePreview(String projectPath, AstNode node, int maxLines) {
         if (node == null || projectPath == null || projectPath.isBlank()) return null;
@@ -1323,12 +2207,41 @@ public class CodestyleService {
             List<String> lines = Files.readAllLines(file, StandardCharsets.UTF_8);
             int start = Math.max(0, node.getStartLine());
             if (start >= lines.size()) return null;
+            String nodeType = node.getNodeType();
+            boolean isMethodOrFunction = "method".equals(nodeType) || "function".equals(nodeType);
+            if (isMethodOrFunction) {
+                int bodyStart = findMethodBodyStart(lines, start);
+                if (bodyStart > start && bodyStart < lines.size()) {
+                    start = bodyStart;
+                }
+            }
             StringBuilder sb = new StringBuilder();
             int count = 0;
+            boolean inDocstring = false;
+            String docQuote = null;
             for (int i = start; i < lines.size() && count < maxLines; i++) {
                 String line = lines.get(i);
                 String trimmed = line.trim();
                 if (trimmed.isEmpty()) continue;
+
+                // Skip Python docstring (""" or ''')
+                if (!inDocstring) {
+                    if (trimmed.startsWith("\"\"\"") || trimmed.startsWith("'''")) {
+                        docQuote = trimmed.substring(0, 3);
+                        if (trimmed.length() > 3 && trimmed.endsWith(docQuote)) {
+                            continue;
+                        }
+                        inDocstring = true;
+                        continue;
+                    }
+                } else {
+                    if (trimmed.contains(docQuote)) {
+                        inDocstring = false;
+                        docQuote = null;
+                    }
+                    continue;
+                }
+
                 if (trimmed.startsWith("//") || trimmed.startsWith("#") || trimmed.startsWith("*")
                         || trimmed.startsWith("/*") || trimmed.startsWith("*/") || trimmed.startsWith("* ")) continue;
                 sb.append(trimmed);
@@ -1339,6 +2252,23 @@ public class CodestyleService {
         } catch (IOException | SecurityException ignored) {
             return null;
         }
+    }
+
+    /** 从 startLine 起找到函数体开始行（签名结束的下一行）。支持 ):  ){  ) ->  ); 等结尾。 */
+    private static int findMethodBodyStart(List<String> lines, int startLine) {
+        for (int i = startLine; i < lines.size(); i++) {
+            String trimmed = lines.get(i).trim();
+            if (trimmed.isEmpty()) continue;
+            if (trimmed.startsWith("//") || trimmed.startsWith("#")) continue;
+            if (trimmed.endsWith("):") || trimmed.endsWith("){") || trimmed.endsWith(") {")
+                    || trimmed.endsWith(") ->") || trimmed.endsWith(");")) {
+                return i + 1;
+            }
+            if (trimmed.contains("):") || trimmed.contains("){") || trimmed.contains(") ->") || trimmed.contains(");")) {
+                return i + 1;
+            }
+        }
+        return startLine;
     }
 
     private static String compactOneLine(String signature, String fallback) {

--- a/src/main/java/top/codestyle/mcp/service/DependencyGraphBuilder.java
+++ b/src/main/java/top/codestyle/mcp/service/DependencyGraphBuilder.java
@@ -57,7 +57,7 @@ public class DependencyGraphBuilder {
             for (AstNode child : f.getChildren()) {
                 String nt = child.getNodeType();
                 if ("class".equals(nt) || "interface".equals(nt) || "enum".equals(nt)) {
-                    currentClass = child.getName();
+                    currentClass = extractSimpleName(child.getName(), nt);
                     String classId = "class:" + path + ":" + currentClass;
                     graph.addVertex(classId);
                     nodeIndex.put(classId, child);
@@ -80,8 +80,32 @@ public class DependencyGraphBuilder {
                             }
                         }
                     }
+                    if (child.getChildren() != null) {
+                        for (AstNode member : child.getChildren()) {
+                            if ("method".equals(member.getNodeType())) {
+                                String methodName = extractSimpleName(member.getName(), "method");
+                                if (methodName == null || methodName.isBlank()) continue;
+                                String methodId = "method:" + path + ":" + currentClass + "." + methodName;
+                                graph.addVertex(methodId);
+                                nodeIndex.put(methodId, member);
+                                addEdge(graph, edgeTypeIndex, classId, methodId, "contains", 1.0);
+                                skeleton.getDependencies().add(ProjectSkeleton.DependencyEdge.builder()
+                                        .source(classId).target(methodId).type("contains").weight(1.0).build());
+                                List<String> invRefs = member.getReferences();
+                                if (invRefs == null) invRefs = List.of();
+                                for (String inv : invRefs) {
+                                    String targetId = resolveInvocation(inv, path, currentClass, skeleton, nodeIndex);
+                                    if (targetId != null) {
+                                        addEdge(graph, edgeTypeIndex, methodId, targetId, "invokes", 0.5);
+                                        skeleton.getDependencies().add(ProjectSkeleton.DependencyEdge.builder()
+                                                .source(methodId).target(targetId).type("invokes").weight(0.5).build());
+                                    }
+                                }
+                            }
+                        }
+                    }
                 } else if ("method".equals(nt)) {
-                    String methodName = child.getName();
+                    String methodName = extractSimpleName(child.getName(), "method");
                     String methodId = currentClass != null
                             ? "method:" + path + ":" + currentClass + "." + methodName
                             : "method:" + path + ":" + methodName;
@@ -139,6 +163,39 @@ public class DependencyGraphBuilder {
         } catch (Exception ignored) {}
     }
 
+    /**
+     * 从 AST 节点的 name 字段提取纯标识符名称。
+     * Python AST 解析器返回完整声明如 "class PGGraphStorage(BaseGraphStorage):" 或 "async def edge_degrees_batch("。
+     * 此方法提取 "PGGraphStorage" 或 "edge_degrees_batch"。
+     */
+    static String extractSimpleName(String raw, String nodeType) {
+        if (raw == null || raw.isBlank()) return raw;
+        String t = raw.trim();
+        if ("class".equals(nodeType) || "interface".equals(nodeType) || "enum".equals(nodeType)) {
+            if (t.startsWith("class ")) t = t.substring("class ".length());
+            else if (t.startsWith("interface ")) t = t.substring("interface ".length());
+            else if (t.startsWith("enum ")) t = t.substring("enum ".length());
+            int cut = Integer.MAX_VALUE;
+            for (char c : new char[]{'(', ':', '{', '<', ' '}) {
+                int idx = t.indexOf(c);
+                if (idx >= 0 && idx < cut) cut = idx;
+            }
+            if (cut < Integer.MAX_VALUE) t = t.substring(0, cut);
+            return t.trim();
+        }
+        if ("method".equals(nodeType) || "function".equals(nodeType)) {
+            if (t.startsWith("async ")) t = t.substring("async ".length());
+            if (t.startsWith("def ")) t = t.substring("def ".length());
+            else if (t.startsWith("function ")) t = t.substring("function ".length());
+            int paren = t.indexOf('(');
+            if (paren >= 0) t = t.substring(0, paren);
+            int space = t.indexOf(' ');
+            if (space >= 0) t = t.substring(0, space);
+            return t.trim();
+        }
+        return t;
+    }
+
     private String resolveImportTarget(String importText, Set<String> allFiles, ProjectSkeleton skeleton) {
         if (importText == null || importText.isBlank()) return null;
         String trimmed = importText.trim();
@@ -187,9 +244,12 @@ public class DependencyGraphBuilder {
         for (AstNode f : skeleton.getFileNodes()) {
             if (f.getChildren() == null) continue;
             for (AstNode c : f.getChildren()) {
-                if (("class".equals(c.getNodeType()) || "interface".equals(c.getNodeType()) || "enum".equals(c.getNodeType()))
-                        && simple.equals(c.getName())) {
-                    return "class:" + f.getFilePath() + ":" + c.getName();
+                String nt = c.getNodeType();
+                if ("class".equals(nt) || "interface".equals(nt) || "enum".equals(nt)) {
+                    String cName = extractSimpleName(c.getName(), nt);
+                    if (simple.equals(cName)) {
+                        return "class:" + f.getFilePath() + ":" + cName;
+                    }
                 }
             }
         }

--- a/src/main/java/top/codestyle/mcp/service/ExploreCodeService.java
+++ b/src/main/java/top/codestyle/mcp/service/ExploreCodeService.java
@@ -1,0 +1,32 @@
+package top.codestyle.mcp.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolParam;
+import org.springframework.stereotype.Service;
+import top.codestyle.mcp.config.ConditionalOnCodestyleToolGroup;
+
+/**
+ * 仅当 codestyle.tool-group 包含 explore 时注册，暴露 exploreCodeContext 工具。
+ * analyze 组 = fast-analysis（analyzeProject） + explore（exploreCodeContext），共 2 个工具；默认组 all 时也会注册。
+ */
+@Service
+@RequiredArgsConstructor
+@ConditionalOnCodestyleToolGroup("explore")
+public class ExploreCodeService {
+
+    private final CodestyleService codestyleService;
+
+    @McpTool(name = "exploreCodeContext", description = "[必填projectPath,mode,query] 代码读取: "
+            + "expand(批量读代码,支持file:start-end|f2), search(按名搜索), trace(上下游调用链).",
+            annotations = @McpTool.McpAnnotations(title = "Explore Code Context", readOnlyHint = true, destructiveHint = false, idempotentHint = true, openWorldHint = false))
+    public String exploreCodeContext(
+            @McpToolParam(description = "项目目录绝对路径（analyzeProject 会自动缓存骨架）") String projectPath,
+            @McpToolParam(description = "模式: expand / trace / search") String mode,
+            @McpToolParam(description = "查询目标: 文件路径、类名、方法名或搜索关键词。expand 支持 | 分隔批量，如 'file1.py:100-200|file2.py:300-400'") String query,
+            @McpToolParam(required = false, description = "trace 模式方向: upstream / downstream / both (默认 both)") String direction,
+            @McpToolParam(required = false, description = "最大遍历深度 (默认 3)") Integer maxDepth,
+            @McpToolParam(required = false, description = "expand 模式可选: 行范围如 '100-200'（1基，含端点）") String lineRange) {
+        return codestyleService.exploreCodeContext(projectPath, mode, query, direction, maxDepth, lineRange);
+    }
+}

--- a/src/main/java/top/codestyle/mcp/service/NameIndex.java
+++ b/src/main/java/top/codestyle/mcp/service/NameIndex.java
@@ -46,10 +46,13 @@ public final class NameIndex {
             String name = n.getName();
             if (name != null && !name.isBlank()) {
                 index(exact, lower, name, id);
+                String simpleName = DependencyGraphBuilder.extractSimpleName(name, n.getNodeType());
+                if (simpleName != null && !simpleName.isBlank() && !simpleName.equals(name)) {
+                    index(exact, lower, simpleName, id);
+                }
                 if (id.startsWith("method:") && name.contains(".")) {
-                    index(exact, lower, name, id);
-                    String simple = name.substring(name.lastIndexOf('.') + 1);
-                    if (!simple.isBlank()) index(exact, lower, simple, id);
+                    String dotSimple = name.substring(name.lastIndexOf('.') + 1);
+                    if (!dotSimple.isBlank()) index(exact, lower, dotSimple, id);
                 }
             }
 

--- a/src/main/java/top/codestyle/mcp/service/ProjectAnalysisService.java
+++ b/src/main/java/top/codestyle/mcp/service/ProjectAnalysisService.java
@@ -1,0 +1,37 @@
+package top.codestyle.mcp.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolParam;
+import org.springframework.stereotype.Service;
+import top.codestyle.mcp.config.ConditionalOnCodestyleToolGroup;
+
+import java.util.Arrays;
+
+/**
+ * P0: 一站式代码分析 MCP 工具。单次调用完成 skeleton + search + expand + 调用链，减少 LLM 轮次与 post-MCP 原生验证。
+ */
+@Service
+@RequiredArgsConstructor
+@ConditionalOnCodestyleToolGroup("fast-analysis")
+public class ProjectAnalysisService {
+
+    private final CodestyleService codestyleService;
+
+    @McpTool(
+            name = "analyzeProject",
+            annotations = @McpTool.McpAnnotations(title = "Code Analysis", readOnlyHint = true, destructiveHint = false, idempotentHint = true, openWorldHint = false),
+            description = "代码分析: keywords传3-6个函数名, 返回位置+签名+调用链+预览. 后续用exploreCodeContext(expand)读代码."
+    )
+    public String analyzeProject(
+            @McpToolParam(description = "项目目录绝对路径") String projectPath,
+            @McpToolParam(description = "3-6个核心函数/类名,逗号分隔,如: aquery_llm,kg_query") String keywords,
+            @McpToolParam(required = false, description = "聚焦子目录,如 'src/main'") String focusPath) {
+        if (keywords == null || keywords.isBlank()) {
+            return "✗ 缺少参数 keywords（逗号分隔的搜索关键词）";
+        }
+        String[] parts = keywords.split("[,，\\s]+");
+        String[] trimmed = Arrays.stream(parts).map(String::strip).filter(s -> !s.isEmpty()).toArray(String[]::new);
+        return codestyleService.runAnalyze(projectPath, trimmed, focusPath);
+    }
+}

--- a/src/main/java/top/codestyle/mcp/service/SkeletonCacheService.java
+++ b/src/main/java/top/codestyle/mcp/service/SkeletonCacheService.java
@@ -7,6 +7,11 @@ import top.codestyle.mcp.model.ast.DependencyGraph;
 import top.codestyle.mcp.model.ast.ProjectSkeleton;
 
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -28,7 +33,12 @@ public class SkeletonCacheService {
 
     public record CachedSkeleton(ProjectSkeleton skeleton, DependencyGraph graph, NameIndex nameIndex, long buildTime) {}
 
+    public record ExploredEntry(String mode, String query, int hitCount, long timestamp) {}
+
     private record CacheEntry(CachedSkeleton data, long expireAt) {}
+
+    private final ConcurrentHashMap<String, List<ExploredEntry>> explorationHistory = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Set<String>> analyzedKeywordsMap = new ConcurrentHashMap<>();
 
     private static String normalizeKey(String projectPath) {
         if (projectPath == null || projectPath.isBlank()) return "";
@@ -66,10 +76,45 @@ public class SkeletonCacheService {
     }
 
     public void invalidate(String projectPath) {
-        cache.remove(normalizeKey(projectPath));
+        String key = normalizeKey(projectPath);
+        cache.remove(key);
+        explorationHistory.remove(key);
+        analyzedKeywordsMap.remove(key);
     }
 
     public void invalidateAll() {
         cache.clear();
+        explorationHistory.clear();
+        analyzedKeywordsMap.clear();
+    }
+
+    public void recordExplore(String projectPath, String mode, String query, int hitCount) {
+        String key = normalizeKey(projectPath);
+        if (key.isEmpty()) return;
+        explorationHistory.computeIfAbsent(key, k -> Collections.synchronizedList(new ArrayList<>()))
+                .add(new ExploredEntry(mode != null ? mode : "", query != null ? query : "", hitCount, System.currentTimeMillis()));
+    }
+
+    public List<ExploredEntry> getExploreHistory(String projectPath) {
+        String key = normalizeKey(projectPath);
+        List<ExploredEntry> list = explorationHistory.get(key);
+        return list != null ? List.copyOf(list) : List.of();
+    }
+
+    public void recordAnalyzedKeywords(String projectPath, Collection<String> keywords) {
+        String key = normalizeKey(projectPath);
+        if (key.isEmpty() || keywords == null || keywords.isEmpty()) return;
+        Set<String> set = analyzedKeywordsMap.computeIfAbsent(key, k -> ConcurrentHashMap.newKeySet());
+        for (String kw : keywords) {
+            if (kw == null) continue;
+            String s = kw.strip();
+            if (!s.isEmpty()) set.add(s);
+        }
+    }
+
+    public Set<String> getAnalyzedKeywords(String projectPath) {
+        String key = normalizeKey(projectPath);
+        Set<String> set = analyzedKeywordsMap.get(key);
+        return set != null ? Set.copyOf(set) : Set.of();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,7 +39,9 @@ sandbox:
     fallback-local: ${CODESTYLE_SANDBOX_DOCKER_FALLBACK_LOCAL:true}
 
 # 项目骨架解析与图构建（AstParsingService, DependencyGraphBuilder）
-# P4: tool-group=all 默认注册全部；code-analysis 仅 2 个代码分析工具；template 仅模板工具
+# 工具组: all（默认）= 全部工具; analyze = analyzeProject + exploreCodeContext（2工具）
+#   fast-analysis = 仅 analyzeProject; explore = 仅 exploreCodeContext
+#   code-analysis = 仅 extractProjectSkeleton; template = 模板7工具
 codestyle:
   tool-group: ${CODESTYLE_TOOL_GROUP:all}
   skeleton:


### PR DESCRIPTION
## PR 类型

<!-- 请选择一种类型 -->

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [X] 📝 文档更新
- [X] 🎨 代码优化/重构
- [X] ⚡ 性能优化
- [ ] ✅ 测试相关
- [ ] 🔧 配置/构建相关
- [ ] 🌐 国际化/本地化
- [ ] 其他

## 相关 Issue

> #27 

## 修改与新增功能

### 1. 新增能力

| 项目 | 说明 |
|------|------|
| **analyzeProject 工具** | 新增一站式代码分析 MCP 工具：传入 `projectPath` + 3～6 个 `keywords`（核心函数/类名），一次返回 Summary、Call Flow、每个关键词的位置（file:startLine-endLine）、签名与代码预览；内部自动完成 skeleton 构建与缓存，无需先调 `extractProjectSkeleton`。 | | **ProjectAnalysisService** | 新增服务类，在 `codestyle.tool-group=analyze`（或 fast-analysis）时注册并暴露 `analyzeProject`。 | | **ExploreCodeService** | 新增服务类，在 `codestyle.tool-group=analyze`（或 explore）时单独暴露 `exploreCodeContext`，与 analyze 组配合使用。 | | **runAnalyze 流水线** | 在 `CodestyleService` 中新增完整分析流水线：增量分析、关键词缓存、按关键词预算的报告生成（含 Call Flow、per-keyword 预览与截断）。 |

### 2. 行为与配置修改

| 项目 | 原始版 (PR) | 修改版 |
|------|-------------|--------|
| **工具组默认值** | `codestyle.tool-group` 默认 `all`，暴露 code-analysis + template。 | 默认改为 `analyze`：仅暴露 **analyzeProject + exploreCodeContext** 两个工具，不暴露 `extractProjectSkeleton`，减少 tools/list 体积与误用。 | | **CodestyleToolGroupCondition** | 仅支持 `code-analysis` / `template` / `all`。 | 支持 `analyze`（默认）、`fast-analysis`、`explore`、`code-analysis`、`template`、`all`；默认组 `analyze` 只注册上述 2 个工具。 |

### 3. 四项优化

| 优化 | 说明 |
|------|------|
| **全命中缓存场景压缩** | 当 `analyzeProject` 处于增量模式且本次所有 keywords 均已命中缓存（`newlyAdded.isEmpty()`）时，不再逐关键词输出多行 `[cached summary]`，改为**单段简短摘要**：列出已分析的关键词并提示使用 `exploreCodeContext(mode=expand)` 读代码，减少约 400 字符/次（约 150 tokens）。 | | **expand 批量预算公平分配** | 批量 expand 使用独立常量 `EXPAND_BATCH_MAX_CHARS = 12_000`，按目标数均分：`perTargetBudget = max(500, 12_000 / targets.length)`，避免前面目标占满预算导致后面目标被整体截断。原版使用 `MCP_MAX_INLINE_CHARS` 且未单独为 batch 设 12K 预算。 | | **tool description 精简** | `analyzeProject` 描述压缩至约 80 字符：「代码分析: keywords传3-6个函数名, 返回位置+签名+调用链+预览. 后续用exploreCodeContext(expand)读代码.」；`exploreCodeContext` 描述改为更聚焦的「代码读取: expand(批量读代码...), search, trace(上下游调用链)」，降低 tools/list 的 token 占用。 | | **Cursor Rule 中 trace 引导** | 在使用 MCP 的 Cursor 仓库（如 Pipeline）的 `.cursor/rules` 中增加「标准工作流」与「调用关系」说明，明确在理解调用关系时使用 `exploreCodeContext(mode=trace, query="函数名")` 追踪上下游（该 Rule 位于使用方仓库，不在此 server 仓库内）。 |

### 4.更新README.md

## 测试步骤
- [X] 本地测试通过
- [ ] 添加/更新了单元测试
- [X] 文档已更新

以下步骤用于验证：**在 Cursor 中接入本 MCP server 后**，能按「先 analyzeProject 再 exploreCodeContext」完成理解与修改任务，并体现 opt-a/opt-b 及 trace 引导的效果，基于[LightRAG](https://github.com/HKUDS/LightRAG)项目。

### Task1：用 MCP 理解 LightRAG 的两条核心管线
#### （直接使用下面的提示词）

按需、优先使用以下MCP：exploreCodeContext、analyzeProject对项目进行分析和理解： LightRAG项目是如何实现：
1、生成知识图谱，即从输入文件到生成最终的知识图谱？
2、对知识图谱的检索与回答，即如何通过自然语言提问到基于知识图谱的回答？

### Task2：在 LightRAG 上做两项代码修改（验证 MCP 辅助下的实现质量与效率）
#### （直接使用下面的提示词）

按需、优先使用以下MCP：exploreCodeContext、analyzeProject对项目进行分析和理解： 1、修改insert函数，在导入RAG之前，先用fuzzywuzzy库对提取出来的所有nodes基于语义相似度做粗聚类（最多20个词一组），接着让大模型判断需要合并的nodes，接着对相似nodes调用merge_entities函数进行合并 2、修改query函数，在调用大模型提取High-level keywords和Low-level  keywords的阶段，使其不仅基于问题本身，还额外基于用户画像和提问意图提取关键词

## 测试结果

- **分步**
  - **Task1（理解 LightRAG 知识图谱构建与检索流程）**：MCP 与 No-MCP 在流程完整性与代码引用精度上持平，但 MCP 用 2 次 MCP 调用即获得全局视图，探索轮次与 token 更少（约 **40w vs 52w，节省约 23%**）。
  - **Task2（insert 粗聚类+合并与 query 用户画像/意图关键词）**：MCP 方案在架构（函数拆分、callback、可测试性）、聚类与 LLM 提示设计上**明显优于** No-MCP，且 token **213w vs 271w，节省约 21.4%**。
- **整体**
  - 总 token：**253w（MCP） vs 323w（No-MCP），节省约 21.7%**。

## 截图/日志
<img width="1540" height="138" alt="Token_Consumption_No_MCP" src="https://github.com/user-attachments/assets/465c2f89-e4ee-4903-8fc9-b93cc05fb161" />
不使用MCP的token消耗

<img width="1550" height="210" alt="Token_Consumption_MCP" src="https://github.com/user-attachments/assets/2c0e06ad-e87f-4ec8-bd61-d2c845653cc1" />
使用MCP的token消耗

## 检查清单

- [ ] 代码遵循项目的代码规范
- [X] 已自测所有改动
- [X] 已更新相关文档
- [X] 提交信息清晰明确
- [X] PR 标题简洁明了
